### PR TITLE
fix: invalid argument 1: hex number

### DIFF
--- a/src/contracts/deposits-registry/sanity-checker/integrity-checker/integrity-checker.service.ts
+++ b/src/contracts/deposits-registry/sanity-checker/integrity-checker/integrity-checker.service.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { RepositoryService } from 'contracts/repository';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { BlockTag } from 'provider';
 import { DepositTree } from './deposit-tree';
 import {
   VerifiedDepositEvent,
@@ -131,7 +130,7 @@ export class DepositIntegrityCheckerService {
    * @param {BlockTag | undefined} blockTag - Specific block number or tag to retrieve the deposit root for.
    * @returns {Promise<string>} Promise that resolves with the deposit root.
    */
-  public async getDepositRoot(blockHash?: BlockTag): Promise<string> {
+  public async getDepositRoot(blockHash: string): Promise<string> {
     const contract = await this.repositoryService.getCachedDepositContract();
     const overrides = { blockTag: { blockHash } };
     const depositRoot = await contract.get_deposit_root(overrides as any);

--- a/src/contracts/deposits-registry/sanity-checker/integrity-checker/integrity-checker.service.ts
+++ b/src/contracts/deposits-registry/sanity-checker/integrity-checker/integrity-checker.service.ts
@@ -58,14 +58,14 @@ export class DepositIntegrityCheckerService {
    * @returns {Promise<void>} A promise that resolves if the roots match, otherwise throws an error.
    */
   public async checkLatestRoot(
-    blockNumber: number,
+    blockHash: string,
     eventsCache: VerifiedDepositEvent[],
   ): Promise<boolean> {
     const tree = await this.putLatestEvents(
       eventsCache.sort((a, b) => a.depositCount - b.depositCount),
     );
 
-    return this.checkRoot(blockNumber, tree);
+    return this.checkRoot(blockHash, tree);
   }
 
   /**
@@ -74,8 +74,8 @@ export class DepositIntegrityCheckerService {
    * @param {string | number} tag - Block Tag to check the deposit root against.
    * @returns {Promise<void>} A promise that resolves if the roots match, otherwise throws an error.
    */
-  public async checkFinalizedRoot(tag: string | number): Promise<boolean> {
-    return this.checkRoot(tag, this.finalizedTree);
+  public async checkFinalizedRoot(blockHash: string): Promise<boolean> {
+    return this.checkRoot(blockHash, this.finalizedTree);
   }
 
   /**
@@ -84,13 +84,13 @@ export class DepositIntegrityCheckerService {
    * @param {DepositTree} tree - Deposit tree to use for comparison.
    * @returns {Promise<void>} A promise that resolves if the roots match, otherwise logs an error and throws.
    */
-  private async checkRoot(tag: string | number, tree: DepositTree) {
+  private async checkRoot(blockHash: string, tree: DepositTree) {
     const localRoot = tree.getRoot();
-    const remoteRoot = await this.getDepositRoot(tag);
+    const remoteRoot = await this.getDepositRoot(blockHash);
 
     if (localRoot === remoteRoot) {
       this.logger.log('Integrity check successfully completed', {
-        tag,
+        blockHash,
       });
       return true;
     }
@@ -131,11 +131,10 @@ export class DepositIntegrityCheckerService {
    * @param {BlockTag | undefined} blockTag - Specific block number or tag to retrieve the deposit root for.
    * @returns {Promise<string>} Promise that resolves with the deposit root.
    */
-  public async getDepositRoot(blockTag?: BlockTag): Promise<string> {
+  public async getDepositRoot(blockHash?: BlockTag): Promise<string> {
     const contract = await this.repositoryService.getCachedDepositContract();
-    const depositRoot = await contract.get_deposit_root({
-      blockTag: blockTag as any,
-    });
+    const overrides = { blockTag: { blockHash } };
+    const depositRoot = await contract.get_deposit_root(overrides as any);
 
     return depositRoot;
   }

--- a/src/contracts/deposits-registry/sanity-checker/sanity-checker.service.ts
+++ b/src/contracts/deposits-registry/sanity-checker/sanity-checker.service.ts
@@ -24,11 +24,11 @@ export class DepositRegistrySanityCheckerService {
   }
   // putLatestEvents
   private async checkFreshEvents(
-    blockNumber: number,
+    blockHash: string,
     events: VerifiedDepositEvent[],
   ) {
     return await this.depositsIntegrityChecker.checkLatestRoot(
-      blockNumber,
+      blockHash,
       events,
     );
   }
@@ -134,14 +134,14 @@ export class DepositRegistrySanityCheckerService {
 
     // Check if the deposit root of the events matches the expected values.
     const isDepositRootMatches = await this.checkFreshEvents(
-      blockNumber,
+      blockHash,
       freshEvents,
     );
 
     return isDepositRootMatches;
   }
 
-  public async verifyUpdatedEvents(tag: string | number) {
-    return this.depositsIntegrityChecker.checkFinalizedRoot(tag);
+  public async verifyUpdatedEvents(blockHash: string) {
+    return this.depositsIntegrityChecker.checkFinalizedRoot(blockHash);
   }
 }


### PR DESCRIPTION
### Investigating the "invalid argument 1: hex number" Error in Ethereum Contract Interactions

#### Context
Developers often face the "invalid argument 1: hex number" error when interacting with Ethereum smart contracts using the ethers.js library. This error is generally triggered by incorrect handling of block tags, particularly in complex transaction structures or asynchronous calls. Here’s an examination of how this error occurs and the right way to handle block tags to avoid it.

#### Error Reproduction
The error can be reproduced by passing a block hash directly as a block tag in an override for a contract method:

```javascript
// Incorrect usage triggering the error
{
  blockTag: blockHash
}
```
Rather than using the correct structure:

```javascript
// Correct structure
{
  blockTag: { blockHash }
}
```

#### Internal Mechanics in ethers.js
The `buildCall` function from the `@ethersproject/contract` package manages method arguments and handles transaction overrides. A key snippet from this function is:

```javascript
function buildCall(contract: Contract, fragment: FunctionFragment, collapseSimple: boolean): ContractFunction {
    ...
    // Extract and await resolution of the "blockTag" override, if present
    if (args.length === fragment.inputs.length + 1 && typeof(args[args.length - 1]) === "object") {
        const overrides = shallowCopy(args.pop());
        if (overrides.blockTag != null) {
            blockTag = await overrides.blockTag;
        }
        ...
    }
    ...
    const result = await signerOrProvider.call(tx, blockTag);
}
```

The `blockTag` resolution passes through various checks until it reaches the `_getBlockTag` method in the `BaseProvider`:

```javascript
async _getBlockTag(blockTag: BlockTag | Promise<BlockTag>): Promise<BlockTag> {
    ...
    // The block tag is formatted according to specific rules
    return this.formatter.blockTag(blockTag);
}
```

#### The Role of the Formatter
Here's a critical detail in the formatter’s implementation that helps prevent the block hash from being incorrectly formatted, which is a common source of errors:

```javascript
blockTag(blockTag: any): any {
    if (
      typeof blockTag === 'object' &&
      blockTag != null &&
      (blockTag.blockNumber || blockTag.blockHash)
    ) {
      // Directly returns the blockTag object if it is well-structured
      return blockTag;
    }

    // Calls the superclass method to handle other types of block tags
    return super.blockTag(blockTag);
}
```

This method checks if the `blockTag` is an object with either a `blockNumber` or `blockHash`. If so, it returns the `blockTag` as is, bypassing the need for further formatting which could "break" the hash. If not, it passes the `blockTag` to the superclass method for standard processing.

#### The `hexValue` Function
This function is crucial as it formats the input value to ensure it's a properly padded hex string, often where the error arises if not handled properly:

```javascript
export function hexValue(value: BytesLike | Hexable | number | bigint): string {
    const trimmed = hexStripZeros(hexlify(value, { hexPad: "left" }));
    if (trimmed === "0x") { return "0x0"; }
    return trimmed;
}
```

#### Conclusion
To prevent the "invalid argument 1: hex number" error, ensure block tags are correctly formatted and encapsulated when passing them as overrides in contract interactions.