### PR TITLE
feat: add RPC metrics collection

### DIFF
--- a/docs/rpc-metrics-testing.md
+++ b/docs/rpc-metrics-testing.md
@@ -1,0 +1,141 @@
+# RPC Metrics Testing Guide
+
+This guide explains how to test the new RPC metrics locally using Prometheus and Grafana.
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+- Node.js and Yarn installed
+- Valid `.env` configuration
+
+## Quick Start
+
+### 1. Start Prometheus and Grafana
+
+```bash
+docker-compose -f docker-compose.metrics.yml up -d
+```
+
+This starts:
+- **Prometheus** on http://localhost:9090
+- **Grafana** on http://localhost:8001 (login: admin/admin)
+
+### 2. Start the Application
+
+```bash
+yarn start:dev
+```
+
+The application exposes metrics on `http://localhost:3004/metrics`.
+
+### 3. Verify Metrics
+
+Run the verification script:
+
+```bash
+./scripts/check-rpc-metrics.sh
+```
+
+Or manually check:
+
+```bash
+curl -s http://localhost:3004/metrics | grep council_daemon_http_rpc
+```
+
+## New RPC Metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `council_daemon_http_rpc_requests_total` | Counter | Total HTTP requests to RPC providers |
+| `council_daemon_http_rpc_batch_size` | Histogram | Number of JSON-RPC calls per HTTP request |
+| `council_daemon_http_rpc_response_seconds` | Histogram | RPC response time distribution |
+| `council_daemon_http_rpc_request_payload_bytes` | Histogram | Request payload size |
+| `council_daemon_http_rpc_response_payload_bytes` | Histogram | Response payload size |
+| `council_daemon_rpc_request_total` | Counter | Individual RPC method calls |
+
+### Labels
+
+All metrics include these labels:
+- `network` - Network identifier (`ethereum` or `data-bus`)
+- `layer` - Layer type (`el` for execution layer)
+- `chain_id` - Chain ID
+- `provider` - RPC provider domain (normalized)
+
+Additional labels per metric:
+- `http_rpc_requests_total`: `batched`, `response_code`, `result`
+- `rpc_request_total`: `method`, `result`, `rpc_error_code`
+
+## PromQL Queries
+
+### Request Rate by Network
+
+```promql
+sum by (network, result) (rate(council_daemon_http_rpc_requests_total[1m]))
+```
+
+### P95 Response Time
+
+```promql
+histogram_quantile(0.95, sum by (le, network) (rate(council_daemon_http_rpc_response_seconds_bucket[5m])))
+```
+
+### RPC Methods Distribution
+
+```promql
+topk(10, sum by (method) (rate(council_daemon_rpc_request_total[5m])))
+```
+
+### Error Rate
+
+```promql
+sum(rate(council_daemon_http_rpc_requests_total{result="fail"}[5m]))
+/
+sum(rate(council_daemon_http_rpc_requests_total[5m]))
+```
+
+### Batch Size Distribution
+
+```promql
+histogram_quantile(0.5, sum by (le) (rate(council_daemon_http_rpc_batch_size_bucket[5m])))
+```
+
+### Payload Sizes
+
+```promql
+# Average request size
+rate(council_daemon_http_rpc_request_payload_bytes_sum[5m]) / rate(council_daemon_http_rpc_request_payload_bytes_count[5m])
+
+# Average response size
+rate(council_daemon_http_rpc_response_payload_bytes_sum[5m]) / rate(council_daemon_http_rpc_response_payload_bytes_count[5m])
+```
+
+## Troubleshooting
+
+### Metrics not appearing
+
+1. Check if the application started successfully:
+   ```bash
+   curl http://localhost:3004/health
+   ```
+
+2. Check RpcMetricsService logs for initialization:
+   ```
+   RPC metrics initialized for ethereum/el (chainId: ...)
+   RPC metrics initialized for data-bus/el (chainId: ...)
+   ```
+
+3. Verify Prometheus can reach the application:
+   - Open http://localhost:9090/targets
+   - Check if `council-daemon` target is UP
+
+### No data in Grafana
+
+1. Verify Prometheus datasource is configured correctly
+2. Check if Prometheus is scraping metrics: http://localhost:9090/graph
+3. Wait for scrape interval (5 seconds)
+
+## Cleanup
+
+```bash
+docker-compose -f docker-compose.metrics.yml down
+```

--- a/grafana/datasources.yml
+++ b/grafana/datasources.yml
@@ -5,11 +5,10 @@ datasources:
     type: prometheus
     access: proxy
     orgId: 1
-    url: http://docker.for.mac.host.internal:9090
+    url: http://council_daemon_prometheus:9090
     basicAuth: false
     isDefault: true
     editable: true
     jsonData:
-      graphiteVersion: '1.1'
       tlsAuth: false
       tlsAuthWithCACert: false

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,8 +1,8 @@
 global:
   scrape_interval: 5s
+
 scrape_configs:
   - job_name: 'council-daemon'
     static_configs:
-      - targets: ['docker.for.mac.host.internal:3003']
-remote_write:
-  - url: https://localhost/api/v1/write
+      - targets: ['host.docker.internal:3004']
+    metrics_path: /metrics

--- a/scripts/check-rpc-metrics.sh
+++ b/scripts/check-rpc-metrics.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# RPC Metrics Verification Script
+# Usage: ./scripts/check-rpc-metrics.sh [port]
+
+PORT=${1:-3004}
+BASE_URL="http://localhost:${PORT}/metrics"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "=========================================="
+echo "  RPC Metrics Verification"
+echo "  Target: ${BASE_URL}"
+echo "=========================================="
+echo ""
+
+# Check if metrics endpoint is available
+if ! curl -s --fail "${BASE_URL}" > /dev/null 2>&1; then
+    echo -e "${RED}ERROR: Cannot reach metrics endpoint at ${BASE_URL}${NC}"
+    echo "Make sure the application is running on port ${PORT}"
+    exit 1
+fi
+
+echo -e "${GREEN}Metrics endpoint is accessible${NC}"
+echo ""
+
+# Fetch metrics once
+METRICS=$(curl -s "${BASE_URL}")
+
+# Define expected metrics
+EXPECTED_METRICS=(
+    "council_daemon_http_rpc_requests_total"
+    "council_daemon_http_rpc_batch_size"
+    "council_daemon_http_rpc_response_seconds"
+    "council_daemon_http_rpc_request_payload_bytes"
+    "council_daemon_http_rpc_response_payload_bytes"
+    "council_daemon_rpc_request_total"
+)
+
+echo "Checking RPC metrics registration..."
+echo "-----------------------------------"
+
+all_found=true
+for metric in "${EXPECTED_METRICS[@]}"; do
+    if echo "$METRICS" | grep -q "^# HELP ${metric}"; then
+        echo -e "${GREEN}[REGISTERED]${NC} ${metric}"
+    else
+        echo -e "${YELLOW}[NOT FOUND]${NC} ${metric}"
+        all_found=false
+    fi
+done
+
+echo ""
+echo "Checking for actual metric data..."
+echo "-----------------------------------"
+
+has_data=false
+for metric in "${EXPECTED_METRICS[@]}"; do
+    count=$(echo "$METRICS" | grep -c "^${metric}")
+    if [ "$count" -gt 0 ]; then
+        echo -e "${GREEN}[HAS DATA]${NC} ${metric}: ${count} series"
+        has_data=true
+    fi
+done
+
+if [ "$has_data" = false ]; then
+    echo -e "${YELLOW}No metric data yet. This is normal if no RPC calls have been made.${NC}"
+fi
+
+echo ""
+echo "Network breakdown..."
+echo "-----------------------------------"
+
+# Check for ethereum network metrics
+eth_count=$(echo "$METRICS" | grep -c 'network="ethereum"')
+databus_count=$(echo "$METRICS" | grep -c 'network="data-bus"')
+
+echo "Ethereum network metrics: ${eth_count}"
+echo "Data-bus network metrics: ${databus_count}"
+
+echo ""
+echo "Sample metrics output..."
+echo "-----------------------------------"
+echo "$METRICS" | grep "council_daemon_http_rpc" | head -20
+
+echo ""
+echo "=========================================="
+if [ "$all_found" = true ]; then
+    echo -e "${GREEN}All RPC metrics are registered!${NC}"
+else
+    echo -e "${YELLOW}Some metrics are not yet registered.${NC}"
+    echo "They will appear after RPC calls are made."
+fi
+echo "=========================================="

--- a/scripts/start-metrics-stack.sh
+++ b/scripts/start-metrics-stack.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Start Prometheus + Grafana metrics stack
+# Usage: ./scripts/start-metrics-stack.sh
+
+set -e
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo "Starting metrics stack..."
+
+docker-compose -f docker-compose.metrics.yml up -d
+
+echo ""
+echo -e "${GREEN}Metrics stack is running!${NC}"
+echo ""
+echo "Services:"
+echo "  - Prometheus: http://localhost:9090"
+echo "  - Grafana:    http://localhost:8001 (admin/admin)"
+echo ""
+echo -e "${YELLOW}Next steps:${NC}"
+echo "  1. Start the application: yarn start:dev"
+echo "  2. Check metrics: ./scripts/check-rpc-metrics.sh"
+echo "  3. Open Prometheus: http://localhost:9090/targets"
+echo ""
+echo "To stop: docker-compose -f docker-compose.metrics.yml down"

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,11 +1,17 @@
 import { Module } from '@nestjs/common';
+import { SimpleFallbackJsonRpcBatchProvider } from '@lido-nestjs/execution';
 import { AppService } from 'app.service';
 
-import { ConfigModule } from 'common/config';
+import { ConfigModule, Configuration } from 'common/config';
 import { LoggerModule } from 'common/logger';
-import { PrometheusModule } from 'common/prometheus';
+import {
+  PrometheusModule,
+  RpcMetricsPrometheusService,
+} from 'common/prometheus';
+import { RpcMetricsModule } from 'common/rpc-metrics';
 import { GuardianModule } from 'guardian';
 import { MainProviderModule } from 'provider/main-provider.module';
+import { DATA_BUS_PROVIDER_TOKEN } from 'provider/data-bus-provider.module';
 import { HealthModule } from 'health';
 import { RepositoryModule } from 'contracts/repository';
 
@@ -18,6 +24,36 @@ import { RepositoryModule } from 'contracts/repository';
     GuardianModule,
     HealthModule,
     RepositoryModule,
+    RpcMetricsModule.forRootAsync(
+      {
+        useFactory: (
+          config: Configuration,
+          mainProvider: SimpleFallbackJsonRpcBatchProvider,
+          dataBusProvider: SimpleFallbackJsonRpcBatchProvider,
+        ) => ({
+          providers: [
+            {
+              network: 'ethereum',
+              chainId: config.CHAIN_ID,
+              layer: 'el',
+              providerFactory: () => mainProvider,
+            },
+            {
+              network: 'data-bus',
+              chainId: config.EVM_CHAIN_DATA_BUS_CHAIN_ID,
+              layer: 'el',
+              providerFactory: () => dataBusProvider,
+            },
+          ],
+        }),
+        inject: [
+          Configuration,
+          SimpleFallbackJsonRpcBatchProvider,
+          DATA_BUS_PROVIDER_TOKEN,
+        ],
+      },
+      { useExisting: RpcMetricsPrometheusService },
+    ),
   ],
   providers: [AppService],
 })

--- a/src/common/prometheus/index.ts
+++ b/src/common/prometheus/index.ts
@@ -1,3 +1,4 @@
 export * from './prometheus.constants';
 export * from './prometheus.module';
 export * from './prometheus.provider';
+export * from './rpc-metrics-prometheus.service';

--- a/src/common/prometheus/prometheus.constants.ts
+++ b/src/common/prometheus/prometheus.constants.ts
@@ -33,3 +33,11 @@ export const METRIC_DUPLICATED_KEYS_TOTAL = `${METRICS_PREFIX}duplicated_keys_to
 export const METRIC_INVALID_KEYS_TOTAL = `${METRICS_PREFIX}invalid_keys_total`;
 
 export const METRIC_JOB_DURATION = `${METRICS_PREFIX}handle_job_duration`;
+
+// RPC Metrics
+export const METRIC_HTTP_RPC_REQUESTS_TOTAL = `${METRICS_PREFIX}http_rpc_requests_total`;
+export const METRIC_HTTP_RPC_BATCH_SIZE = `${METRICS_PREFIX}http_rpc_batch_size`;
+export const METRIC_HTTP_RPC_RESPONSE_SECONDS = `${METRICS_PREFIX}http_rpc_response_seconds`;
+export const METRIC_HTTP_RPC_REQUEST_PAYLOAD_BYTES = `${METRICS_PREFIX}http_rpc_request_payload_bytes`;
+export const METRIC_HTTP_RPC_RESPONSE_PAYLOAD_BYTES = `${METRICS_PREFIX}http_rpc_response_payload_bytes`;
+export const METRIC_RPC_REQUEST_TOTAL = `${METRICS_PREFIX}rpc_request_total`;

--- a/src/common/prometheus/prometheus.module.ts
+++ b/src/common/prometheus/prometheus.module.ts
@@ -20,8 +20,15 @@ import {
   PrometheusDataBusAccountBalanceProvider,
   PrometheusDataBusRPCRequestsHistogramProvider,
   PrometheusJobDurationProvider,
+  PrometheusHttpRpcRequestsTotalProvider,
+  PrometheusHttpRpcBatchSizeProvider,
+  PrometheusHttpRpcResponseSecondsProvider,
+  PrometheusHttpRpcRequestPayloadBytesProvider,
+  PrometheusHttpRpcResponsePayloadBytesProvider,
+  PrometheusRpcRequestTotalProvider,
 } from './prometheus.provider';
 import { METRICS_PREFIX, METRICS_URL } from './prometheus.constants';
+import { RpcMetricsPrometheusService } from './rpc-metrics-prometheus.service';
 
 export const PrometheusModule = PrometheusModuleSource.register({
   path: METRICS_URL,
@@ -52,6 +59,14 @@ const providers = [
   PrometheusInvalidKeysProvider,
   PrometheusUnvetKeysCounterProvider,
   PrometheusJobDurationProvider,
+  // RPC Metrics providers
+  PrometheusHttpRpcRequestsTotalProvider,
+  PrometheusHttpRpcBatchSizeProvider,
+  PrometheusHttpRpcResponseSecondsProvider,
+  PrometheusHttpRpcRequestPayloadBytesProvider,
+  PrometheusHttpRpcResponsePayloadBytesProvider,
+  PrometheusRpcRequestTotalProvider,
+  RpcMetricsPrometheusService,
 ];
 
 PrometheusModule.global = true;

--- a/src/common/prometheus/prometheus.provider.ts
+++ b/src/common/prometheus/prometheus.provider.ts
@@ -24,6 +24,12 @@ import {
   METRIC_DATA_BUS_RPC_REQUEST_DURATION,
   METRIC_DATA_BUS_RPC_REQUEST_ERRORS,
   METRIC_JOB_DURATION,
+  METRIC_HTTP_RPC_REQUESTS_TOTAL,
+  METRIC_HTTP_RPC_BATCH_SIZE,
+  METRIC_HTTP_RPC_RESPONSE_SECONDS,
+  METRIC_HTTP_RPC_REQUEST_PAYLOAD_BYTES,
+  METRIC_HTTP_RPC_RESPONSE_PAYLOAD_BYTES,
+  METRIC_RPC_REQUEST_TOTAL,
 } from './prometheus.constants';
 
 export const PrometheusTransportMessageCounterProvider = makeCounterProvider({
@@ -143,4 +149,63 @@ export const PrometheusJobDurationProvider = makeHistogramProvider({
   help: 'Job duration',
   buckets: [0.1, 0.3, 1, 3, 5, 10, 30, 60, 100, 180, 300],
   labelNames: ['jobName', 'stakingModuleId'] as const,
+});
+
+// RPC Metrics providers
+export const PrometheusHttpRpcRequestsTotalProvider = makeCounterProvider({
+  name: METRIC_HTTP_RPC_REQUESTS_TOTAL,
+  help: 'Total HTTP requests to RPC providers',
+  labelNames: [
+    'network',
+    'layer',
+    'chain_id',
+    'provider',
+    'batched',
+    'response_code',
+    'result',
+  ] as const,
+});
+
+export const PrometheusHttpRpcBatchSizeProvider = makeHistogramProvider({
+  name: METRIC_HTTP_RPC_BATCH_SIZE,
+  help: 'Distribution of JSON-RPC calls bundled in each HTTP request',
+  buckets: [1, 2, 5, 10, 20, 50, 100],
+  labelNames: ['network', 'layer', 'chain_id', 'provider'] as const,
+});
+
+export const PrometheusHttpRpcResponseSecondsProvider = makeHistogramProvider({
+  name: METRIC_HTTP_RPC_RESPONSE_SECONDS,
+  help: 'Distribution of RPC response times in seconds',
+  buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+  labelNames: ['network', 'layer', 'chain_id', 'provider'] as const,
+});
+
+export const PrometheusHttpRpcRequestPayloadBytesProvider =
+  makeHistogramProvider({
+    name: METRIC_HTTP_RPC_REQUEST_PAYLOAD_BYTES,
+    help: 'Distribution of request payload sizes in bytes',
+    buckets: [128, 256, 512, 1024, 2048, 4096, 8192, 16384],
+    labelNames: ['network', 'layer', 'chain_id', 'provider'] as const,
+  });
+
+export const PrometheusHttpRpcResponsePayloadBytesProvider =
+  makeHistogramProvider({
+    name: METRIC_HTTP_RPC_RESPONSE_PAYLOAD_BYTES,
+    help: 'Distribution of response payload sizes in bytes',
+    buckets: [128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536],
+    labelNames: ['network', 'layer', 'chain_id', 'provider'] as const,
+  });
+
+export const PrometheusRpcRequestTotalProvider = makeCounterProvider({
+  name: METRIC_RPC_REQUEST_TOTAL,
+  help: 'Total number of individual RPC method calls',
+  labelNames: [
+    'network',
+    'layer',
+    'chain_id',
+    'provider',
+    'method',
+    'result',
+    'rpc_error_code',
+  ] as const,
 });

--- a/src/common/prometheus/rpc-metrics-prometheus.service.ts
+++ b/src/common/prometheus/rpc-metrics-prometheus.service.ts
@@ -1,0 +1,30 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { Counter, Histogram } from 'prom-client';
+import { getToken } from '@willsoto/nestjs-prometheus';
+import {
+  METRIC_HTTP_RPC_REQUESTS_TOTAL,
+  METRIC_HTTP_RPC_BATCH_SIZE,
+  METRIC_HTTP_RPC_RESPONSE_SECONDS,
+  METRIC_HTTP_RPC_REQUEST_PAYLOAD_BYTES,
+  METRIC_HTTP_RPC_RESPONSE_PAYLOAD_BYTES,
+  METRIC_RPC_REQUEST_TOTAL,
+} from './prometheus.constants';
+import { RpcMetricsRegistry } from 'common/rpc-metrics';
+
+@Injectable()
+export class RpcMetricsPrometheusService implements RpcMetricsRegistry {
+  constructor(
+    @Inject(getToken(METRIC_HTTP_RPC_REQUESTS_TOTAL))
+    public readonly httpRpcRequestsTotal: Counter<string>,
+    @Inject(getToken(METRIC_HTTP_RPC_BATCH_SIZE))
+    public readonly httpRpcBatchSize: Histogram<string>,
+    @Inject(getToken(METRIC_HTTP_RPC_RESPONSE_SECONDS))
+    public readonly httpRpcResponseSeconds: Histogram<string>,
+    @Inject(getToken(METRIC_HTTP_RPC_REQUEST_PAYLOAD_BYTES))
+    public readonly httpRpcRequestPayloadBytes: Histogram<string>,
+    @Inject(getToken(METRIC_HTTP_RPC_RESPONSE_PAYLOAD_BYTES))
+    public readonly httpRpcResponsePayloadBytes: Histogram<string>,
+    @Inject(getToken(METRIC_RPC_REQUEST_TOTAL))
+    public readonly rpcRequestTotal: Counter<string>,
+  ) {}
+}

--- a/src/common/rpc-metrics/index.ts
+++ b/src/common/rpc-metrics/index.ts
@@ -1,0 +1,1 @@
+export * from './src';

--- a/src/common/rpc-metrics/src/index.ts
+++ b/src/common/rpc-metrics/src/index.ts
@@ -1,0 +1,4 @@
+export * from './rpc-metrics.module';
+export * from './rpc-metrics.service';
+export * from './rpc-metrics.constants';
+export * from './interfaces';

--- a/src/common/rpc-metrics/src/interfaces/index.ts
+++ b/src/common/rpc-metrics/src/interfaces/index.ts
@@ -1,0 +1,2 @@
+export * from './rpc-metrics.interface';
+export * from './prometheus-metrics.interface';

--- a/src/common/rpc-metrics/src/interfaces/prometheus-metrics.interface.ts
+++ b/src/common/rpc-metrics/src/interfaces/prometheus-metrics.interface.ts
@@ -1,0 +1,101 @@
+/**
+ * Interface for the metrics registry that RpcMetricsService expects.
+ * Implement this interface in your PrometheusService or metrics provider.
+ */
+export interface RpcMetricsRegistry {
+  /** Counter: Total HTTP requests used by RPC layer */
+  httpRpcRequestsTotal: MetricCounter<HttpRpcRequestLabels>;
+
+  /** Histogram: Distribution of JSON-RPC calls bundled in each HTTP request */
+  httpRpcBatchSize: MetricHistogram<BaseRpcLabels>;
+
+  /** Histogram: Distribution of RPC response times in seconds */
+  httpRpcResponseSeconds: MetricHistogram<BaseRpcLabels>;
+
+  /** Histogram: Distribution of request payload sizes in bytes */
+  httpRpcRequestPayloadBytes: MetricHistogram<BaseRpcLabels>;
+
+  /** Histogram: Distribution of response payload sizes in bytes */
+  httpRpcResponsePayloadBytes: MetricHistogram<BaseRpcLabels>;
+
+  /** Counter: Total number of individual RPC method calls */
+  rpcRequestTotal: MetricCounter<RpcRequestLabels>;
+}
+
+export interface BaseRpcLabels {
+  network: string;
+  layer: string;
+  chain_id: string;
+  provider: string;
+  [key: string]: string;
+}
+
+export interface HttpRpcRequestLabels extends BaseRpcLabels {
+  batched: string;
+  response_code: string;
+  result: string;
+}
+
+export interface RpcRequestLabels extends BaseRpcLabels {
+  method: string;
+  result: string;
+  rpc_error_code: string;
+}
+
+export interface MetricCounter<T extends Record<string, string>> {
+  inc(labels: T, value?: number): void;
+}
+
+export interface MetricHistogram<T extends Record<string, string>> {
+  observe(labels: T, value: number): void;
+}
+
+/**
+ * Example implementation with prom-client:
+ *
+ * ```typescript
+ * import { Counter, Histogram } from 'prom-client';
+ *
+ * export class PrometheusService implements RpcMetricsRegistry {
+ *   httpRpcRequestsTotal = new Counter({
+ *     name: 'http_rpc_requests_total',
+ *     help: 'Counts total HTTP requests used by RPC layer',
+ *     labelNames: ['network', 'layer', 'chain_id', 'provider', 'batched', 'response_code', 'result'],
+ *   });
+ *
+ *   httpRpcBatchSize = new Histogram({
+ *     name: 'http_rpc_batch_size',
+ *     help: 'Distribution of JSON-RPC calls bundled in each HTTP request',
+ *     buckets: [1, 2, 5, 10, 20, 50, 100],
+ *     labelNames: ['network', 'layer', 'chain_id', 'provider'],
+ *   });
+ *
+ *   httpRpcResponseSeconds = new Histogram({
+ *     name: 'http_rpc_response_seconds',
+ *     help: 'Distribution of RPC response times in seconds',
+ *     buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+ *     labelNames: ['network', 'layer', 'chain_id', 'provider'],
+ *   });
+ *
+ *   httpRpcRequestPayloadBytes = new Histogram({
+ *     name: 'http_rpc_request_payload_bytes',
+ *     help: 'Distribution of request payload sizes in bytes',
+ *     buckets: [128, 256, 512, 1024, 2048, 4096, 8192, 16384],
+ *     labelNames: ['network', 'layer', 'chain_id', 'provider'],
+ *   });
+ *
+ *   httpRpcResponsePayloadBytes = new Histogram({
+ *     name: 'http_rpc_response_payload_bytes',
+ *     help: 'Distribution of response payload sizes in bytes',
+ *     buckets: [128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536],
+ *     labelNames: ['network', 'layer', 'chain_id', 'provider'],
+ *   });
+ *
+ *   rpcRequestTotal = new Counter({
+ *     name: 'rpc_request_total',
+ *     help: 'Total number of RPC requests',
+ *     labelNames: ['network', 'layer', 'chain_id', 'provider', 'method', 'result', 'rpc_error_code'],
+ *   });
+ * }
+ * ```
+ */

--- a/src/common/rpc-metrics/src/interfaces/rpc-metrics.interface.ts
+++ b/src/common/rpc-metrics/src/interfaces/rpc-metrics.interface.ts
@@ -1,0 +1,85 @@
+export interface EventEmitterLike {
+  on(event: string, listener: (...args: any[]) => void): this;
+  off(event: string, listener: (...args: any[]) => void): this;
+}
+
+export interface RpcProviderConfig {
+  /** Network name (e.g., 'ethereum', 'gnosis') */
+  network: string;
+  /** Chain ID */
+  chainId: string | number;
+  /** Layer identifier (e.g., 'el' for execution layer, 'cl' for consensus layer) */
+  layer: string;
+  /** Provider with event emitter for tracking RPC events */
+  providerFactory: () => ProviderWithEvents | Promise<ProviderWithEvents>;
+}
+
+export interface RpcMetricsModuleOptions {
+  /** List of providers to track */
+  providers: RpcProviderConfig[];
+}
+
+export interface RpcMetricsModuleAsyncOptions {
+  imports?: any[];
+  useFactory: (
+    ...args: any[]
+  ) => RpcMetricsModuleOptions | Promise<RpcMetricsModuleOptions>;
+  inject?: any[];
+}
+
+export interface ProviderWithEvents {
+  eventEmitter?: EventEmitterLike;
+}
+
+export interface BaseMetricLabels {
+  network: string;
+  layer: string;
+  chain_id: string;
+  provider: string;
+  [key: string]: string;
+}
+
+export interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id: string | number;
+  method: string;
+  params?: any[];
+}
+
+export interface JsonRpcError {
+  code: number;
+  message: string;
+  data?: any;
+}
+
+export interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id: string | number;
+  result?: any;
+  error?: JsonRpcError;
+}
+
+export interface RpcRequestBatchedEvent {
+  action: 'provider:request-batched';
+  domain: string;
+  request: JsonRpcRequest[];
+}
+
+export interface RpcResponseBatchedEvent {
+  action: 'provider:response-batched';
+  domain: string;
+  request: JsonRpcRequest[];
+  response: JsonRpcResponse | JsonRpcResponse[];
+}
+
+export interface RpcResponseBatchedErrorEvent {
+  action: 'provider:response-batched:error';
+  domain: string;
+  request: JsonRpcRequest[];
+  error: Error & { status?: number };
+}
+
+export type RpcEvent =
+  | RpcRequestBatchedEvent
+  | RpcResponseBatchedEvent
+  | RpcResponseBatchedErrorEvent;

--- a/src/common/rpc-metrics/src/rpc-metrics.constants.ts
+++ b/src/common/rpc-metrics/src/rpc-metrics.constants.ts
@@ -1,0 +1,16 @@
+export const RPC_METRICS_CONSTANTS = {
+  RESPONSE_CODES: {
+    SUCCESS: '2xx',
+    CLIENT_ERROR: '4xx',
+    SERVER_ERROR: '5xx',
+  },
+  RESULTS: {
+    SUCCESS: 'success',
+    FAIL: 'fail',
+  },
+  PROVIDERS: {
+    UNKNOWN: 'unknown',
+  },
+} as const;
+
+export const RPC_METRICS_CONFIG = 'RPC_METRICS_CONFIG';

--- a/src/common/rpc-metrics/src/rpc-metrics.module.ts
+++ b/src/common/rpc-metrics/src/rpc-metrics.module.ts
@@ -1,0 +1,128 @@
+import { DynamicModule, Module, Provider } from '@nestjs/common';
+import { RpcMetricsService, RPC_METRICS_REGISTRY } from './rpc-metrics.service';
+import { RPC_METRICS_CONFIG } from './rpc-metrics.constants';
+import {
+  RpcMetricsModuleOptions,
+  RpcMetricsModuleAsyncOptions,
+} from './interfaces/rpc-metrics.interface';
+import { RpcMetricsRegistry } from './interfaces/prometheus-metrics.interface';
+
+@Module({})
+export class RpcMetricsModule {
+  /**
+   * Register the RPC metrics module with static configuration
+   *
+   * @example
+   * ```typescript
+   * RpcMetricsModule.forRoot({
+   *   network: 'ethereum',
+   *   chainId: 1,
+   *   layer: 'el',
+   *   providerFactory: () => myProvider,
+   * }, prometheusService)
+   * ```
+   */
+  static forRoot(
+    options: RpcMetricsModuleOptions,
+    metricsRegistry: RpcMetricsRegistry,
+  ): DynamicModule {
+    return {
+      module: RpcMetricsModule,
+      providers: [
+        {
+          provide: RPC_METRICS_CONFIG,
+          useValue: options,
+        },
+        {
+          provide: RPC_METRICS_REGISTRY,
+          useValue: metricsRegistry,
+        },
+        RpcMetricsService,
+      ],
+      exports: [RpcMetricsService],
+    };
+  }
+
+  /**
+   * Register the RPC metrics module with async configuration
+   *
+   * @example
+   * ```typescript
+   * RpcMetricsModule.forRootAsync({
+   *   imports: [ConfigModule, ProviderModule],
+   *   useFactory: (configService, providerService) => ({
+   *     network: configService.get('NETWORK'),
+   *     chainId: configService.get('CHAIN_ID'),
+   *     layer: 'el',
+   *     providerFactory: () => providerService.getProvider(),
+   *   }),
+   *   inject: [ConfigService, ProviderService],
+   * }, {
+   *   useExisting: PrometheusService,
+   * })
+   * ```
+   */
+  static forRootAsync(
+    options: RpcMetricsModuleAsyncOptions,
+    metricsRegistryProvider: MetricsRegistryProvider,
+  ): DynamicModule {
+    const configProvider: Provider = {
+      provide: RPC_METRICS_CONFIG,
+      useFactory: options.useFactory,
+      inject: options.inject || [],
+    };
+
+    const registryProvider = this.createMetricsRegistryProvider(
+      metricsRegistryProvider,
+    );
+
+    return {
+      module: RpcMetricsModule,
+      imports: options.imports || [],
+      providers: [configProvider, registryProvider, RpcMetricsService],
+      exports: [RpcMetricsService],
+    };
+  }
+
+  private static createMetricsRegistryProvider(
+    provider: MetricsRegistryProvider,
+  ): Provider {
+    if ('useExisting' in provider) {
+      return {
+        provide: RPC_METRICS_REGISTRY,
+        useExisting: provider.useExisting,
+      };
+    }
+    if ('useClass' in provider) {
+      return {
+        provide: RPC_METRICS_REGISTRY,
+        useClass: provider.useClass,
+      };
+    }
+    if ('useFactory' in provider) {
+      return {
+        provide: RPC_METRICS_REGISTRY,
+        useFactory: provider.useFactory,
+        inject: provider.inject || [],
+      };
+    }
+    if ('useValue' in provider) {
+      return {
+        provide: RPC_METRICS_REGISTRY,
+        useValue: provider.useValue,
+      };
+    }
+    throw new Error('Invalid metrics registry provider configuration');
+  }
+}
+
+export type MetricsRegistryProvider =
+  | { useExisting: any }
+  | { useClass: any }
+  | {
+      useFactory: (
+        ...args: any[]
+      ) => RpcMetricsRegistry | Promise<RpcMetricsRegistry>;
+      inject?: any[];
+    }
+  | { useValue: RpcMetricsRegistry };

--- a/src/common/rpc-metrics/src/rpc-metrics.service.ts
+++ b/src/common/rpc-metrics/src/rpc-metrics.service.ts
@@ -1,0 +1,341 @@
+import {
+  Injectable,
+  OnModuleInit,
+  OnModuleDestroy,
+  Logger,
+  Inject,
+} from '@nestjs/common';
+import {
+  RPC_METRICS_CONSTANTS,
+  RPC_METRICS_CONFIG,
+} from './rpc-metrics.constants';
+import {
+  RpcMetricsModuleOptions,
+  RpcProviderConfig,
+  BaseMetricLabels,
+  JsonRpcRequest,
+  JsonRpcResponse,
+  RpcEvent,
+  ProviderWithEvents,
+  EventEmitterLike,
+} from './interfaces/rpc-metrics.interface';
+import { RpcMetricsRegistry } from './interfaces/prometheus-metrics.interface';
+
+export const RPC_METRICS_REGISTRY = 'RPC_METRICS_REGISTRY';
+
+interface ProviderContext {
+  config: RpcProviderConfig;
+  provider: ProviderWithEvents;
+  cleanup: () => void;
+}
+
+@Injectable()
+export class RpcMetricsService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(RpcMetricsService.name);
+  private providerContexts: ProviderContext[] = [];
+  private pendingRequests = new Map<
+    string,
+    { startTime: number; config: RpcProviderConfig }
+  >();
+
+  constructor(
+    @Inject(RPC_METRICS_CONFIG)
+    private readonly options: RpcMetricsModuleOptions,
+    @Inject(RPC_METRICS_REGISTRY)
+    private readonly metricsRegistry: RpcMetricsRegistry,
+  ) {}
+
+  async onModuleInit() {
+    for (const config of this.options.providers) {
+      try {
+        const provider = await config.providerFactory();
+        const cleanup = this.setupEventListeners(provider, config);
+        this.providerContexts.push({ config, provider, cleanup });
+        this.logger.log(
+          `RPC metrics initialized for ${config.network}/${config.layer} (chainId: ${config.chainId})`,
+        );
+      } catch (error) {
+        this.logger.error(
+          `Failed to initialize RPC metrics for ${config.network}/${config.layer}:`,
+          error,
+        );
+      }
+    }
+  }
+
+  onModuleDestroy() {
+    this.providerContexts.forEach((ctx) => ctx.cleanup());
+    this.providerContexts = [];
+    this.pendingRequests.clear();
+  }
+
+  private setupEventListeners(
+    provider: ProviderWithEvents,
+    config: RpcProviderConfig,
+  ): () => void {
+    if (!provider || !this.hasEventEmitter(provider)) {
+      this.logger.warn(
+        `Provider eventEmitter not available for ${config.network}/${config.layer}, RPC metrics will not be tracked`,
+      );
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      return () => {};
+    }
+
+    const emitter = provider.eventEmitter as EventEmitterLike;
+    const rpcEventHandler = (event: RpcEvent) => {
+      this.handleRpcEvent(event, config);
+    };
+
+    emitter.on('rpc', rpcEventHandler);
+    return () => emitter.off('rpc', rpcEventHandler);
+  }
+
+  private hasEventEmitter(provider: ProviderWithEvents): boolean {
+    return provider && typeof provider.eventEmitter?.on === 'function';
+  }
+
+  private handleRpcEvent(event: RpcEvent, config: RpcProviderConfig) {
+    try {
+      switch (event.action) {
+        case 'provider:request-batched':
+          this.trackRequestStart(event, config);
+          break;
+        case 'provider:response-batched':
+          this.trackBatchedResponse(event, config);
+          break;
+        case 'provider:response-batched:error':
+          this.trackBatchedErrorResponse(event, config);
+          break;
+      }
+    } catch (error) {
+      this.logger.error('Error handling RPC event:', error);
+    }
+  }
+
+  private trackRequestStart(
+    event: Extract<RpcEvent, { action: 'provider:request-batched' }>,
+    config: RpcProviderConfig,
+  ) {
+    const requestKey = this.generateRequestKey(event.request, config);
+    this.pendingRequests.set(requestKey, { startTime: Date.now(), config });
+  }
+
+  private trackResponseTime(
+    requests: JsonRpcRequest[],
+    baseLabels: BaseMetricLabels,
+    config: RpcProviderConfig,
+  ) {
+    const requestKey = this.generateRequestKey(requests, config);
+    const pending = this.pendingRequests.get(requestKey);
+
+    if (pending) {
+      const duration = (Date.now() - pending.startTime) / 1000;
+      this.metricsRegistry.httpRpcResponseSeconds.observe(baseLabels, duration);
+      this.pendingRequests.delete(requestKey);
+
+      if (this.pendingRequests.size > 1000) {
+        this.cleanupOldRequests();
+      }
+    }
+  }
+
+  private trackBatchedResponse(
+    event: Extract<RpcEvent, { action: 'provider:response-batched' }>,
+    config: RpcProviderConfig,
+  ) {
+    const baseLabels = this.getBaseLabels(event.domain, config);
+    const batchSize = event.request.length;
+
+    this.metricsRegistry.httpRpcRequestsTotal.inc({
+      ...baseLabels,
+      batched: batchSize > 1 ? 'true' : 'false',
+      response_code: RPC_METRICS_CONSTANTS.RESPONSE_CODES.SUCCESS,
+      result: RPC_METRICS_CONSTANTS.RESULTS.SUCCESS,
+    });
+    this.trackResponseTime(event.request, baseLabels, config);
+
+    this.metricsRegistry.httpRpcBatchSize.observe(baseLabels, batchSize);
+    this.trackPayloadSizes(baseLabels, event.request, event.response);
+    this.trackRpcCallMetrics(
+      event.request,
+      event.response,
+      baseLabels.provider,
+      config,
+    );
+  }
+
+  private trackBatchedErrorResponse(
+    event: Extract<RpcEvent, { action: 'provider:response-batched:error' }>,
+    config: RpcProviderConfig,
+  ) {
+    const baseLabels = this.getBaseLabels(event.domain, config);
+    const batchSize = event.request.length;
+    const errorStatusCode = event.error?.status
+      ? String(event.error.status)
+      : '5xx';
+    const errorCode = errorStatusCode?.startsWith('4')
+      ? RPC_METRICS_CONSTANTS.RESPONSE_CODES.CLIENT_ERROR
+      : RPC_METRICS_CONSTANTS.RESPONSE_CODES.SERVER_ERROR;
+
+    this.metricsRegistry.httpRpcRequestsTotal.inc({
+      ...baseLabels,
+      batched: batchSize > 1 ? 'true' : 'false',
+      response_code: errorCode,
+      result: RPC_METRICS_CONSTANTS.RESULTS.FAIL,
+    });
+
+    this.trackResponseTime(event.request, baseLabels, config);
+    this.metricsRegistry.httpRpcBatchSize.observe(baseLabels, batchSize);
+
+    const requestSize = this.calculatePayloadSize(event.request);
+    this.metricsRegistry.httpRpcRequestPayloadBytes.observe(
+      baseLabels,
+      requestSize,
+    );
+
+    this.trackRpcCallFailures(event.request, baseLabels.provider, config);
+  }
+
+  private getBaseLabels(
+    domain: string,
+    config: RpcProviderConfig,
+  ): BaseMetricLabels {
+    return {
+      network: config.network,
+      layer: config.layer,
+      chain_id: String(config.chainId),
+      provider: this.normalizeProvider(domain),
+    };
+  }
+
+  private trackPayloadSizes(
+    baseLabels: BaseMetricLabels,
+    request: any,
+    response?: any,
+  ) {
+    const requestSize = this.calculatePayloadSize(request);
+    this.metricsRegistry.httpRpcRequestPayloadBytes.observe(
+      baseLabels,
+      requestSize,
+    );
+
+    if (response) {
+      const responseSize = this.calculatePayloadSize(response);
+      this.metricsRegistry.httpRpcResponsePayloadBytes.observe(
+        baseLabels,
+        responseSize,
+      );
+    }
+  }
+
+  private trackRpcCallFailures(
+    requests: JsonRpcRequest[],
+    provider: string,
+    config: RpcProviderConfig,
+  ) {
+    requests.forEach((request) => {
+      this.metricsRegistry.rpcRequestTotal.inc({
+        network: config.network,
+        layer: config.layer,
+        chain_id: String(config.chainId),
+        provider,
+        method: request.method,
+        result: RPC_METRICS_CONSTANTS.RESULTS.FAIL,
+        rpc_error_code: '',
+      });
+    });
+  }
+
+  private trackRpcCallMetrics(
+    requests: JsonRpcRequest[],
+    responses: JsonRpcResponse | JsonRpcResponse[],
+    provider: string,
+    config: RpcProviderConfig,
+  ) {
+    const responseArray = Array.isArray(responses) ? responses : [responses];
+
+    requests.forEach((request, index) => {
+      const response = responseArray[index];
+      const rpcErrorCode = response?.error?.code
+        ? String(response.error.code)
+        : '';
+      const methodResult = response?.error
+        ? RPC_METRICS_CONSTANTS.RESULTS.FAIL
+        : RPC_METRICS_CONSTANTS.RESULTS.SUCCESS;
+
+      this.metricsRegistry.rpcRequestTotal.inc({
+        network: config.network,
+        layer: config.layer,
+        chain_id: String(config.chainId),
+        provider,
+        method: request.method,
+        result: methodResult,
+        rpc_error_code: rpcErrorCode,
+      });
+    });
+  }
+
+  private normalizeProvider(domain: string): string {
+    try {
+      if (!domain) return RPC_METRICS_CONSTANTS.PROVIDERS.UNKNOWN;
+
+      const hostname = this.extractHostname(domain);
+
+      if (this.isIpAddress(hostname)) {
+        return hostname;
+      }
+
+      return this.extractSecondLevelDomain(hostname);
+    } catch {
+      return RPC_METRICS_CONSTANTS.PROVIDERS.UNKNOWN;
+    }
+  }
+
+  private extractHostname(domain: string): string {
+    if (!domain.startsWith('http')) {
+      return domain;
+    }
+
+    const parsed = new URL(domain);
+    return parsed.port ? `${parsed.hostname}:${parsed.port}` : parsed.hostname;
+  }
+
+  private isIpAddress(hostname: string): boolean {
+    return /^\d+\.\d+\.\d+\.\d+(:\d+)?$/.test(hostname);
+  }
+
+  private extractSecondLevelDomain(hostname: string): string {
+    const parts = hostname.split('.');
+    if (parts.length >= 2) {
+      return `${parts[parts.length - 2]}.${
+        parts[parts.length - 1]
+      }`.toLowerCase();
+    }
+    return hostname.toLowerCase();
+  }
+
+  private calculatePayloadSize(data: any): number {
+    try {
+      return Buffer.byteLength(JSON.stringify(data), 'utf8');
+    } catch {
+      return 0;
+    }
+  }
+
+  private generateRequestKey(
+    requests: JsonRpcRequest[],
+    config: RpcProviderConfig,
+  ): string {
+    const ids = requests.map((r) => r.id).join(',');
+    return `${config.network}:${config.layer}:${ids}`;
+  }
+
+  private cleanupOldRequests() {
+    const fiveMinutesAgo = Date.now() - 5 * 60 * 1000;
+    for (const [key, { startTime }] of this.pendingRequests.entries()) {
+      if (startTime < fiveMinutesAgo) {
+        this.pendingRequests.delete(key);
+      }
+    }
+  }
+}

--- a/src/provider/data-bus-provider.module.ts
+++ b/src/provider/data-bus-provider.module.ts
@@ -1,4 +1,4 @@
-import { DynamicModule, Module } from '@nestjs/common';
+import { DynamicModule, Global, Module } from '@nestjs/common';
 import {
   FallbackProviderModule,
   SimpleFallbackJsonRpcBatchProvider,
@@ -11,11 +11,13 @@ import { DATA_BUS_REQUEST_TIMEOUT } from 'contracts/data-bus/data-bus.constants'
 
 export const DATA_BUS_PROVIDER_TOKEN = 'DATA_BUS_PROVIDER';
 
+@Global()
 @Module({})
 export class DataBusProviderModule {
   static forRootAsync(): DynamicModule {
     return {
       module: DataBusProviderModule,
+      global: true,
       imports: [
         FallbackProviderModule.forRootAsync({
           useFactory: async (


### PR DESCRIPTION
Add RPC Metrics for Ethereum and Data-bus Providers
This PR adds comprehensive RPC metrics tracking for both Ethereum main provider and Data-bus provider. The new metrics enable better observability of RPC call performance, error rates, and payload sizes.

A new reusable RpcMetricsModule subscribes to the SimpleFallbackJsonRpcBatchProvider event emitter and tracks metrics per network with labels for network, layer, chain_id, and provider.

New metrics include:

- council_daemon_http_rpc_requests_total - total HTTP requests to RPC providers
- council_daemon_http_rpc_batch_size - JSON-RPC calls bundled per HTTP request
- council_daemon_http_rpc_response_seconds - RPC response time distribution
- council_daemon_http_rpc_request_payload_bytes - request payload size
- council_daemon_http_rpc_response_payload_bytes - response payload size
- council_daemon_rpc_request_total - individual RPC method calls with method, result, and error code labels


DataBusProviderModule was made global to expose DATA_BUS_PROVIDER_TOKEN for metrics initialization. RpcMetricsPrometheusService implements the RpcMetricsRegistry interface to integrate with existing Prometheus setup.