### PR TITLE
feat: enhance RPC metrics with nonce and cache metrics tracking

### DIFF
--- a/scripts/check-rpc-metrics.sh
+++ b/scripts/check-rpc-metrics.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# RPC Metrics Verification Script
+# Metrics Verification Script
 # Usage: ./scripts/check-rpc-metrics.sh [port]
 
 PORT=${1:-3004}
@@ -9,10 +9,11 @@ BASE_URL="http://localhost:${PORT}/metrics"
 GREEN='\033[0;32m'
 RED='\033[0;31m'
 YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
 NC='\033[0m' # No Color
 
 echo "=========================================="
-echo "  RPC Metrics Verification"
+echo "  Guardian Metrics Verification"
 echo "  Target: ${BASE_URL}"
 echo "=========================================="
 echo ""
@@ -30,8 +31,8 @@ echo ""
 # Fetch metrics once
 METRICS=$(curl -s "${BASE_URL}")
 
-# Define expected metrics
-EXPECTED_METRICS=(
+# Define expected metrics by category
+RPC_METRICS=(
     "council_daemon_http_rpc_requests_total"
     "council_daemon_http_rpc_batch_size"
     "council_daemon_http_rpc_response_seconds"
@@ -40,37 +41,68 @@ EXPECTED_METRICS=(
     "council_daemon_rpc_request_total"
 )
 
-echo "Checking RPC metrics registration..."
-echo "-----------------------------------"
+NONCE_METRICS=(
+    "council_daemon_nonce_latest"
+    "council_daemon_nonce_pending"
+    "council_daemon_nonce_gap"
+)
 
-all_found=true
-for metric in "${EXPECTED_METRICS[@]}"; do
-    if echo "$METRICS" | grep -q "^# HELP ${metric}"; then
-        echo -e "${GREEN}[REGISTERED]${NC} ${metric}"
+CACHE_METRICS=(
+    "council_daemon_deposits_cache_bytes"
+    "council_daemon_deposits_cache_count"
+    "council_daemon_signing_keys_cache_bytes"
+    "council_daemon_signing_keys_cache_count"
+)
+
+MESSAGE_METRICS=(
+    "council_daemon_sent_messages_total"
+)
+
+check_metrics() {
+    local category=$1
+    shift
+    local metrics=("$@")
+
+    echo -e "${CYAN}${category}${NC}"
+    echo "-----------------------------------"
+
+    local all_found=true
+    for metric in "${metrics[@]}"; do
+        if echo "$METRICS" | grep -q "^# HELP ${metric}"; then
+            count=$(echo "$METRICS" | grep -c "^${metric}")
+            if [ "$count" -gt 0 ]; then
+                echo -e "${GREEN}[OK]${NC} ${metric} (${count} series)"
+            else
+                echo -e "${GREEN}[REGISTERED]${NC} ${metric} (no data yet)"
+            fi
+        else
+            echo -e "${YELLOW}[NOT FOUND]${NC} ${metric}"
+            all_found=false
+        fi
+    done
+    echo ""
+
+    if [ "$all_found" = true ]; then
+        return 0
     else
-        echo -e "${YELLOW}[NOT FOUND]${NC} ${metric}"
-        all_found=false
+        return 1
     fi
-done
+}
 
+# Check each category
 echo ""
-echo "Checking for actual metric data..."
-echo "-----------------------------------"
+check_metrics "Phase 1: RPC Metrics" "${RPC_METRICS[@]}"
+rpc_ok=$?
 
-has_data=false
-for metric in "${EXPECTED_METRICS[@]}"; do
-    count=$(echo "$METRICS" | grep -c "^${metric}")
-    if [ "$count" -gt 0 ]; then
-        echo -e "${GREEN}[HAS DATA]${NC} ${metric}: ${count} series"
-        has_data=true
-    fi
-done
+check_metrics "Phase 2: Nonce Metrics" "${NONCE_METRICS[@]}"
+nonce_ok=$?
 
-if [ "$has_data" = false ]; then
-    echo -e "${YELLOW}No metric data yet. This is normal if no RPC calls have been made.${NC}"
-fi
+check_metrics "Phase 3: Events Cache Metrics" "${CACHE_METRICS[@]}"
+cache_ok=$?
 
-echo ""
+check_metrics "Phase 4: Message Metrics" "${MESSAGE_METRICS[@]}"
+message_ok=$?
+
 echo "Network breakdown..."
 echo "-----------------------------------"
 
@@ -82,16 +114,21 @@ echo "Ethereum network metrics: ${eth_count}"
 echo "Data-bus network metrics: ${databus_count}"
 
 echo ""
-echo "Sample metrics output..."
+echo "Sample nonce metrics..."
 echo "-----------------------------------"
-echo "$METRICS" | grep "council_daemon_http_rpc" | head -20
+echo "$METRICS" | grep "council_daemon_nonce" | head -10
+
+echo ""
+echo "Sample cache metrics..."
+echo "-----------------------------------"
+echo "$METRICS" | grep "council_daemon_deposits_cache\|council_daemon_signing_keys_cache" | head -10
 
 echo ""
 echo "=========================================="
-if [ "$all_found" = true ]; then
-    echo -e "${GREEN}All RPC metrics are registered!${NC}"
+if [ $rpc_ok -eq 0 ] && [ $nonce_ok -eq 0 ] && [ $cache_ok -eq 0 ] && [ $message_ok -eq 0 ]; then
+    echo -e "${GREEN}All metrics are registered!${NC}"
 else
     echo -e "${YELLOW}Some metrics are not yet registered.${NC}"
-    echo "They will appear after RPC calls are made."
+    echo "They will appear after the corresponding operations occur."
 fi
 echo "=========================================="

--- a/src/common/prometheus/prometheus.constants.ts
+++ b/src/common/prometheus/prometheus.constants.ts
@@ -41,3 +41,14 @@ export const METRIC_HTTP_RPC_RESPONSE_SECONDS = `${METRICS_PREFIX}http_rpc_respo
 export const METRIC_HTTP_RPC_REQUEST_PAYLOAD_BYTES = `${METRICS_PREFIX}http_rpc_request_payload_bytes`;
 export const METRIC_HTTP_RPC_RESPONSE_PAYLOAD_BYTES = `${METRICS_PREFIX}http_rpc_response_payload_bytes`;
 export const METRIC_RPC_REQUEST_TOTAL = `${METRICS_PREFIX}rpc_request_total`;
+
+// Nonce Metrics
+export const METRIC_NONCE_LATEST = `${METRICS_PREFIX}nonce_latest`;
+export const METRIC_NONCE_PENDING = `${METRICS_PREFIX}nonce_pending`;
+export const METRIC_NONCE_GAP = `${METRICS_PREFIX}nonce_gap`;
+
+// Events Cache Metrics
+export const METRIC_DEPOSITS_CACHE_BYTES = `${METRICS_PREFIX}deposits_cache_bytes`;
+export const METRIC_DEPOSITS_CACHE_COUNT = `${METRICS_PREFIX}deposits_cache_count`;
+export const METRIC_SIGNING_KEYS_CACHE_BYTES = `${METRICS_PREFIX}signing_keys_cache_bytes`;
+export const METRIC_SIGNING_KEYS_CACHE_COUNT = `${METRICS_PREFIX}signing_keys_cache_count`;

--- a/src/common/prometheus/prometheus.module.ts
+++ b/src/common/prometheus/prometheus.module.ts
@@ -26,6 +26,13 @@ import {
   PrometheusHttpRpcRequestPayloadBytesProvider,
   PrometheusHttpRpcResponsePayloadBytesProvider,
   PrometheusRpcRequestTotalProvider,
+  PrometheusNonceLatestProvider,
+  PrometheusNoncePendingProvider,
+  PrometheusNonceGapProvider,
+  PrometheusDepositsCacheBytesProvider,
+  PrometheusDepositsCacheCountProvider,
+  PrometheusSigningKeysCacheBytesProvider,
+  PrometheusSigningKeysCacheCountProvider,
 } from './prometheus.provider';
 import { METRICS_PREFIX, METRICS_URL } from './prometheus.constants';
 import { RpcMetricsPrometheusService } from './rpc-metrics-prometheus.service';
@@ -67,6 +74,15 @@ const providers = [
   PrometheusHttpRpcResponsePayloadBytesProvider,
   PrometheusRpcRequestTotalProvider,
   RpcMetricsPrometheusService,
+  // Nonce Metrics providers
+  PrometheusNonceLatestProvider,
+  PrometheusNoncePendingProvider,
+  PrometheusNonceGapProvider,
+  // Events Cache Metrics providers
+  PrometheusDepositsCacheBytesProvider,
+  PrometheusDepositsCacheCountProvider,
+  PrometheusSigningKeysCacheBytesProvider,
+  PrometheusSigningKeysCacheCountProvider,
 ];
 
 PrometheusModule.global = true;

--- a/src/common/prometheus/prometheus.provider.ts
+++ b/src/common/prometheus/prometheus.provider.ts
@@ -30,6 +30,13 @@ import {
   METRIC_HTTP_RPC_REQUEST_PAYLOAD_BYTES,
   METRIC_HTTP_RPC_RESPONSE_PAYLOAD_BYTES,
   METRIC_RPC_REQUEST_TOTAL,
+  METRIC_NONCE_LATEST,
+  METRIC_NONCE_PENDING,
+  METRIC_NONCE_GAP,
+  METRIC_DEPOSITS_CACHE_BYTES,
+  METRIC_DEPOSITS_CACHE_COUNT,
+  METRIC_SIGNING_KEYS_CACHE_BYTES,
+  METRIC_SIGNING_KEYS_CACHE_COUNT,
 } from './prometheus.constants';
 
 export const PrometheusTransportMessageCounterProvider = makeCounterProvider({
@@ -208,4 +215,44 @@ export const PrometheusRpcRequestTotalProvider = makeCounterProvider({
     'result',
     'rpc_error_code',
   ] as const,
+});
+
+// Nonce Metrics providers
+export const PrometheusNonceLatestProvider = makeGaugeProvider({
+  name: METRIC_NONCE_LATEST,
+  help: 'Latest confirmed nonce for guardian address',
+  labelNames: ['network'] as const,
+});
+
+export const PrometheusNoncePendingProvider = makeGaugeProvider({
+  name: METRIC_NONCE_PENDING,
+  help: 'Pending nonce for guardian address',
+  labelNames: ['network'] as const,
+});
+
+export const PrometheusNonceGapProvider = makeGaugeProvider({
+  name: METRIC_NONCE_GAP,
+  help: 'Difference between pending and latest nonce',
+  labelNames: ['network'] as const,
+});
+
+// Events Cache Metrics providers
+export const PrometheusDepositsCacheBytesProvider = makeGaugeProvider({
+  name: METRIC_DEPOSITS_CACHE_BYTES,
+  help: 'Memory used by deposits events cache in bytes',
+});
+
+export const PrometheusDepositsCacheCountProvider = makeGaugeProvider({
+  name: METRIC_DEPOSITS_CACHE_COUNT,
+  help: 'Number of deposit events in cache',
+});
+
+export const PrometheusSigningKeysCacheBytesProvider = makeGaugeProvider({
+  name: METRIC_SIGNING_KEYS_CACHE_BYTES,
+  help: 'Memory used by signing keys events cache in bytes',
+});
+
+export const PrometheusSigningKeysCacheCountProvider = makeGaugeProvider({
+  name: METRIC_SIGNING_KEYS_CACHE_COUNT,
+  help: 'Number of signing key events in cache',
 });

--- a/src/contracts/data-bus/data-bus.service.ts
+++ b/src/contracts/data-bus/data-bus.service.ts
@@ -8,6 +8,9 @@ import {
   METRIC_DATA_BUS_ACCOUNT_BALANCE,
   METRIC_DATA_BUS_RPC_REQUEST_DURATION,
   METRIC_DATA_BUS_RPC_REQUEST_ERRORS,
+  METRIC_NONCE_LATEST,
+  METRIC_NONCE_PENDING,
+  METRIC_NONCE_GAP,
 } from 'common/prometheus';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { Counter, Gauge, Histogram, register } from 'prom-client';
@@ -31,6 +34,9 @@ export class DataBusService {
   constructor(
     @InjectMetric(METRIC_DATA_BUS_ACCOUNT_BALANCE)
     private accountBalance: Gauge<string>,
+    @InjectMetric(METRIC_NONCE_LATEST) private nonceLatest: Gauge<string>,
+    @InjectMetric(METRIC_NONCE_PENDING) private noncePending: Gauge<string>,
+    @InjectMetric(METRIC_NONCE_GAP) private nonceGap: Gauge<string>,
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private logger: LoggerService,
     @Inject(DATA_BUS_PRIVATE_KEY) private privateKey: string,
     @Inject(DATA_BUS_ADDRESS) private dataBusAddress: string,
@@ -71,16 +77,27 @@ export class DataBusService {
   }
 
   /**
-   * Monitors the guardian account balance to ensure it is sufficient for transactions.
-   * Updates the account balance metric.
+   * Monitors the guardian account balance and nonce to ensure it is sufficient for transactions.
+   * Updates the account balance and nonce metrics.
    */
   @OneAtTime()
   public async monitorGuardianDataBusBalance() {
-    const balanceWei = await this.getAccountBalance();
+    const [balanceWei, latestNonce, pendingNonce, network] = await Promise.all([
+      this.getAccountBalance(),
+      this.provider.getTransactionCount(this.address, 'latest'),
+      this.provider.getTransactionCount(this.address, 'pending'),
+      this.provider.getNetwork(),
+    ]);
+
     const balanceETH = formatEther(balanceWei);
-    const { chainId } = await this.provider.getNetwork();
+    const { chainId } = network;
     this.accountBalance.set({ chainId }, Number(balanceETH));
     this.isBalanceSufficient(balanceWei, chainId);
+
+    const gap = pendingNonce - latestNonce;
+    this.nonceLatest.labels({ network: 'data-bus' }).set(latestNonce);
+    this.noncePending.labels({ network: 'data-bus' }).set(pendingNonce);
+    this.nonceGap.labels({ network: 'data-bus' }).set(gap);
   }
 
   /**

--- a/src/contracts/deposits-registry/store/store.service.ts
+++ b/src/contracts/deposits-registry/store/store.service.ts
@@ -14,19 +14,30 @@ import {
   VerifiedDepositEventsCacheHeaders,
 } from '../interfaces';
 import { InjectMetric } from '@willsoto/nestjs-prometheus';
-import { METRIC_JOB_DURATION } from 'common/prometheus';
-import { Histogram } from 'prom-client';
+import {
+  METRIC_JOB_DURATION,
+  METRIC_DEPOSITS_CACHE_BYTES,
+  METRIC_DEPOSITS_CACHE_COUNT,
+} from 'common/prometheus';
+import { Gauge, Histogram } from 'prom-client';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 
 @Injectable()
 export class DepositsRegistryStoreService {
   private db!: Level<string, string>;
   private cache!: VerifiedDepositEventsCache;
+  private cacheSizeBytes = 0;
+  private cacheEventCount = 0;
+
   constructor(
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private logger: LoggerService,
     private provider: SimpleFallbackJsonRpcBatchProvider,
     @InjectMetric(METRIC_JOB_DURATION)
     private jobDurationMetric: Histogram<string>,
+    @InjectMetric(METRIC_DEPOSITS_CACHE_BYTES)
+    private depositsCacheBytesGauge: Gauge<string>,
+    @InjectMetric(METRIC_DEPOSITS_CACHE_COUNT)
+    private depositsCacheCountGauge: Gauge<string>,
     @Inject(DB_DIR) private cacheDir: string,
     @Inject(DB_LAYER_DIR) private cacheLayerDir: string,
     @Inject(DB_DEFAULT_VALUE)
@@ -154,9 +165,19 @@ export class DepositsRegistryStoreService {
 
       const data: VerifiedDepositEvent[] = [];
 
+      // Reset counters before loading
+      this.cacheSizeBytes = 0;
+      this.cacheEventCount = 0;
+
       for await (const [, value] of stream) {
+        // Track size from DB value
+        this.cacheSizeBytes += Buffer.byteLength(value, 'utf8');
+        this.cacheEventCount++;
         data.push(this.parseDepositEvent(value));
       }
+
+      this.updateCacheMetrics();
+
       const headers: VerifiedDepositEventsCacheHeaders = JSON.parse(
         await this.db.get('headers'),
       );
@@ -386,6 +407,7 @@ export class DepositsRegistryStoreService {
 
   /**
    * Serializes a VerifiedDepositEvent into a JSON string, converting `depositDataRoot` from Uint8Array to an array.
+   * Also tracks the serialized size for cache metrics.
    *
    * @param {VerifiedDepositEvent} depositEvent - The deposit event to serialize.
    * @returns {string} The serialized JSON string of the deposit event.
@@ -397,7 +419,22 @@ export class DepositsRegistryStoreService {
       ...rest,
       depositDataRoot: Array.from(depositDataRoot),
     };
-    return JSON.stringify(value);
+    const serialized = JSON.stringify(value);
+
+    // Track size for metrics
+    this.cacheSizeBytes += Buffer.byteLength(serialized, 'utf8');
+    this.cacheEventCount++;
+    this.updateCacheMetrics();
+
+    return serialized;
+  }
+
+  /**
+   * Updates the Prometheus cache metrics
+   */
+  private updateCacheMetrics(): void {
+    this.depositsCacheBytesGauge.set(this.cacheSizeBytes);
+    this.depositsCacheCountGauge.set(this.cacheEventCount);
   }
 
   /**
@@ -449,6 +486,11 @@ export class DepositsRegistryStoreService {
   public async deleteCache(): Promise<void> {
     await this.db.clear();
     this.cache = this.getDefaultCachedValue();
+
+    // Reset cache metrics
+    this.cacheSizeBytes = 0;
+    this.cacheEventCount = 0;
+    this.updateCacheMetrics();
   }
 
   /**

--- a/src/contracts/signing-keys-registry/signing-keys-registry.spec.ts
+++ b/src/contracts/signing-keys-registry/signing-keys-registry.spec.ts
@@ -4,6 +4,7 @@ import { MockProviderModule } from 'provider';
 import { SimpleFallbackJsonRpcBatchProvider } from '@lido-nestjs/execution';
 import { ConfigModule } from 'common/config';
 import { LoggerModule } from 'common/logger';
+import { PrometheusModule } from 'common/prometheus';
 import { RepositoryModule, RepositoryService } from 'contracts/repository';
 import { SigningKeysStoreService, SigningKeysStoreModule } from './store';
 import { mockRepository } from 'contracts/repository/repository.mock';
@@ -31,6 +32,7 @@ describe('SigningKeysRegistryService', () => {
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
       imports: [
+        PrometheusModule,
         ConfigModule.forRoot(),
         MockProviderModule.forRoot(),
         RepositoryModule,

--- a/src/contracts/signing-keys-registry/store/store.service.spec.ts
+++ b/src/contracts/signing-keys-registry/store/store.service.spec.ts
@@ -2,6 +2,7 @@ import { Test } from '@nestjs/testing';
 import { MockProviderModule } from 'provider';
 import { ConfigModule } from 'common/config';
 import { LoggerModule } from 'common/logger';
+import { PrometheusModule } from 'common/prometheus';
 import { SigningKeysStoreModule } from './store.module';
 import { SigningKeysStoreService } from './store.service';
 import { cacheMock, eventsMock1, keyMock1 } from './store.fixtures';
@@ -17,6 +18,7 @@ describe('dbService', () => {
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
       imports: [
+        PrometheusModule,
         ConfigModule.forRoot(),
         MockProviderModule.forRoot(),
         SigningKeysStoreModule.register(

--- a/src/contracts/signing-keys-registry/store/store.service.ts
+++ b/src/contracts/signing-keys-registry/store/store.service.ts
@@ -6,13 +6,26 @@ import { SimpleFallbackJsonRpcBatchProvider } from '@lido-nestjs/execution';
 import { SigningKeyEvent } from '../interfaces/event.interface';
 import { SigningKeyEventsCacheHeaders } from '../interfaces/cache.interface';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { InjectMetric } from '@willsoto/nestjs-prometheus';
+import {
+  METRIC_SIGNING_KEYS_CACHE_BYTES,
+  METRIC_SIGNING_KEYS_CACHE_COUNT,
+} from 'common/prometheus';
+import { Gauge } from 'prom-client';
 
 @Injectable()
 export class SigningKeysStoreService {
   private db!: Level<string, string>;
+  private cacheSizeBytes = 0;
+  private cacheEventCount = 0;
+
   constructor(
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private logger: LoggerService,
     private provider: SimpleFallbackJsonRpcBatchProvider,
+    @InjectMetric(METRIC_SIGNING_KEYS_CACHE_BYTES)
+    private signingKeysCacheBytesGauge: Gauge<string>,
+    @InjectMetric(METRIC_SIGNING_KEYS_CACHE_COUNT)
+    private signingKeysCacheCountGauge: Gauge<string>,
     @Inject(DB_DIR) private cacheDir: string,
     @Inject(DB_LAYER_DIR) private cacheLayerDir: string,
     @Inject(DB_DEFAULT_VALUE)
@@ -93,9 +106,19 @@ export class SigningKeysStoreService {
 
       const data: SigningKeyEvent[] = [];
 
+      // Reset counters before loading
+      this.cacheSizeBytes = 0;
+      this.cacheEventCount = 0;
+
       for await (const [, value] of stream) {
+        // Track size from DB value
+        this.cacheSizeBytes += Buffer.byteLength(value, 'utf8');
+        this.cacheEventCount++;
         data.push(this.parseSigningKeyEvent(value));
       }
+
+      this.updateCacheMetrics();
+
       const headers: SigningKeyEventsCacheHeaders = JSON.parse(
         await this.db.get('headers'),
       );
@@ -188,13 +211,29 @@ export class SigningKeysStoreService {
 
   /**
    * Serializes a SigningKeyEvent into a JSON string.
+   * Also tracks the serialized size for cache metrics.
    *
    * @param {SigningKeyEvent} signingKeyEvent - The signing key event to serialize.
    * @returns {string} The serialized JSON string of the signing key event.
    * @public
    */
   public serializeEventData(signingKeyEvent: SigningKeyEvent) {
-    return JSON.stringify(signingKeyEvent);
+    const serialized = JSON.stringify(signingKeyEvent);
+
+    // Track size for metrics
+    this.cacheSizeBytes += Buffer.byteLength(serialized, 'utf8');
+    this.cacheEventCount++;
+    this.updateCacheMetrics();
+
+    return serialized;
+  }
+
+  /**
+   * Updates the Prometheus cache metrics
+   */
+  private updateCacheMetrics(): void {
+    this.signingKeysCacheBytesGauge.set(this.cacheSizeBytes);
+    this.signingKeysCacheCountGauge.set(this.cacheEventCount);
   }
 
   /**
@@ -258,6 +297,11 @@ export class SigningKeysStoreService {
    */
   public async deleteCache(): Promise<void> {
     await this.db.clear();
+
+    // Reset cache metrics
+    this.cacheSizeBytes = 0;
+    this.cacheEventCount = 0;
+    this.updateCacheMetrics();
   }
 
   /**

--- a/src/guardian/duplicates/keys-duplication-checker.service.spec.ts
+++ b/src/guardian/duplicates/keys-duplication-checker.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { LoggerModule } from 'common/logger';
+import { PrometheusModule } from 'common/prometheus';
 import {
   SigningKeysRegistryModule,
   SigningKeysRegistryService,
@@ -24,6 +25,7 @@ describe('KeysDuplicationCheckerService', () => {
   beforeEach(async () => {
     const moduleRef: TestingModule = await Test.createTestingModule({
       imports: [
+        PrometheusModule,
         StakingRouterModule,
         RepositoryModule,
         ConfigModule.forRoot(),

--- a/src/wallet/wallet.service.ts
+++ b/src/wallet/wallet.service.ts
@@ -12,7 +12,12 @@ import {
 } from '@nestjs/common';
 import { InjectMetric } from '@willsoto/nestjs-prometheus';
 import { OneAtTime } from 'common/decorators';
-import { METRIC_ACCOUNT_BALANCE } from 'common/prometheus';
+import {
+  METRIC_ACCOUNT_BALANCE,
+  METRIC_NONCE_LATEST,
+  METRIC_NONCE_PENDING,
+  METRIC_NONCE_GAP,
+} from 'common/prometheus';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { Gauge, register } from 'prom-client';
 import { SimpleFallbackJsonRpcBatchProvider } from '@lido-nestjs/execution';
@@ -33,6 +38,9 @@ import { Configuration } from 'common/config';
 export class WalletService implements OnModuleInit {
   constructor(
     @InjectMetric(METRIC_ACCOUNT_BALANCE) private accountBalance: Gauge<string>,
+    @InjectMetric(METRIC_NONCE_LATEST) private nonceLatest: Gauge<string>,
+    @InjectMetric(METRIC_NONCE_PENDING) private noncePending: Gauge<string>,
+    @InjectMetric(METRIC_NONCE_GAP) private nonceGap: Gauge<string>,
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private logger: LoggerService,
     @Inject(WALLET_PRIVATE_KEY) private privateKey: string,
     private provider: SimpleFallbackJsonRpcBatchProvider,
@@ -66,15 +74,25 @@ export class WalletService implements OnModuleInit {
   }
 
   /**
-   * Monitors the guardian account balance to ensure it is sufficient for transactions.
-   * Updates the account balance metric.
+   * Monitors the guardian account balance and nonce to ensure it is sufficient for transactions.
+   * Updates the account balance and nonce metrics.
    */
   @OneAtTime()
   public async monitorGuardianBalance() {
-    const balanceWei = await this.getAccountBalance();
+    const [balanceWei, latestNonce, pendingNonce] = await Promise.all([
+      this.getAccountBalance(),
+      this.provider.getTransactionCount(this.address, 'latest'),
+      this.provider.getTransactionCount(this.address, 'pending'),
+    ]);
+
     const balanceETH = formatEther(balanceWei);
     this.accountBalance.set(Number(balanceETH));
     this.isBalanceSufficient(balanceWei);
+
+    const gap = pendingNonce - latestNonce;
+    this.nonceLatest.labels({ network: 'ethereum' }).set(latestNonce);
+    this.noncePending.labels({ network: 'ethereum' }).set(pendingNonce);
+    this.nonceGap.labels({ network: 'ethereum' }).set(gap);
   }
 
   /**


### PR DESCRIPTION
Nonce Metrics (label network: ethereum | data-bus):

- council_daemon_nonce_latest - latest confirmed nonce
- council_daemon_nonce_pending - pending nonce
- council_daemon_nonce_gap - gap between pending and latest nonce

Events Cache Metrics:

- council_daemon_deposits_cache_bytes - size of deposits cache in bytes
- council_daemon_deposits_cache_count - number of deposit events in cache
- council_daemon_signing_keys_cache_bytes - size of signing keys cache in bytes
- council_daemon_signing_keys_cache_count - number of signing key events in cache