### PR TITLE
Consideration legacy wc in historical front-run

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lido-council-daemon",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Lido Council Daemon",
   "author": "Lido team",
   "private": true,

--- a/src/guardian/guardian-metrics/guardian-metrics.service.ts
+++ b/src/guardian/guardian-metrics/guardian-metrics.service.ts
@@ -173,11 +173,11 @@ export class GuardianMetricsService {
     this.invalidKeysCounter.set({ stakingModuleId }, invalidKeysCount);
   }
 
-  public collectHistoricalFrontRunMetrics(
-    frontRunCount: number,
-    wrongWCTypeCount: number,
-  ) {
+  public collectHistoricalFrontRunMetrics(frontRunCount: number) {
     this.historicalFrontRunCounter.set({ type: 'front_run' }, frontRunCount);
+  }
+
+  public collectWrongWCTypeMetrics(wrongWCTypeCount: number) {
     this.historicalFrontRunCounter.set(
       { type: 'wrong_wc_type' },
       wrongWCTypeCount,

--- a/src/guardian/staking-module-guard/staking-module-guard.service.ts
+++ b/src/guardian/staking-module-guard/staking-module-guard.service.ts
@@ -20,6 +20,11 @@ import { DeepReadonly } from 'common/ts-utils';
 import { Configuration } from 'common/config';
 import { getLegacyModuleWCs } from '../withdrawal-credentials';
 
+type UsedKeyExpectedWC = {
+  moduleAddress: string;
+  wc: string;
+};
+
 @Injectable()
 export class StakingModuleGuardService {
   constructor(
@@ -63,29 +68,25 @@ export class StakingModuleGuardService {
   }
 
   /**
-   * Build a map of used lido keys to the withdrawal credentials that are
-   * acceptable for them: the module's current WC plus any legacy WCs the module
-   * legitimately used in the past (e.g. the pre-Merge 0x00 BLS WC). The earliest
-   * deposit of a used key may still be bound to a legacy WC, so it must be
-   * treated as a valid lido WC and not reported as a front-run.
+   * Build a map of used lido keys to their module WC. Legacy WCs are checked
+   * against their cutoff block later, once the earliest deposit block is known.
    */
-  private getUsedKeyAcceptableWCs(
+  private getUsedKeyExpectedWCs(
     lidoKeys: DeepReadonly<RegistryKey[]>,
     moduleAddressToWC: DeepReadonly<Record<string, string>>,
-  ): Map<string, Set<string>> {
-    const usedKeyAcceptableWCs = new Map<string, Set<string>>();
+  ): Map<string, UsedKeyExpectedWC> {
+    const usedKeyExpectedWCs = new Map<string, UsedKeyExpectedWC>();
     for (const key of lidoKeys) {
       if (key.used) {
         const expectedWC = moduleAddressToWC[key.moduleAddress];
         if (!expectedWC) throw new Error('Unexpected module address');
-        const legacyWCs = getLegacyModuleWCs(
-          this.config.CHAIN_ID,
-          key.moduleAddress,
-        );
-        usedKeyAcceptableWCs.set(key.key, new Set([expectedWC, ...legacyWCs]));
+        usedKeyExpectedWCs.set(key.key, {
+          moduleAddress: key.moduleAddress,
+          wc: expectedWC,
+        });
       }
     }
-    return usedKeyAcceptableWCs;
+    return usedKeyExpectedWCs;
   }
 
   /**
@@ -93,12 +94,12 @@ export class StakingModuleGuardService {
    */
   private getEarliestDeposits(
     depositedEvents: VerifiedDepositEventGroup,
-    usedKeyAcceptableWCs: Map<string, Set<string>>,
+    usedKeyExpectedWCs: Map<string, UsedKeyExpectedWC>,
   ): Map<string, VerifiedDepositEvent> {
     const earliestDeposits = new Map<string, VerifiedDepositEvent>();
     for (const event of depositedEvents.events) {
       if (!event.valid) continue;
-      if (!usedKeyAcceptableWCs.has(event.pubkey)) continue;
+      if (!usedKeyExpectedWCs.has(event.pubkey)) continue;
 
       const existing = earliestDeposits.get(event.pubkey);
       if (!existing || this.isFirstEventEarlier(event, existing)) {
@@ -106,6 +107,22 @@ export class StakingModuleGuardService {
       }
     }
     return earliestDeposits;
+  }
+
+  private hasAcceptableWC(
+    event: VerifiedDepositEvent,
+    expectedWC: UsedKeyExpectedWC,
+  ): boolean {
+    if (event.wc === expectedWC.wc) return true;
+
+    return getLegacyModuleWCs(
+      this.config.CHAIN_ID,
+      expectedWC.moduleAddress,
+    ).some(
+      (legacyWC) =>
+        legacyWC.wc.toLowerCase() === event.wc.toLowerCase() &&
+        event.blockNumber <= legacyWC.validUntilBlock,
+    );
   }
 
   /**
@@ -116,23 +133,25 @@ export class StakingModuleGuardService {
     lidoKeys: DeepReadonly<RegistryKey[]>,
     moduleAddressToWC: DeepReadonly<Record<string, string>>,
   ): boolean {
-    const usedKeyAcceptableWCs = this.getUsedKeyAcceptableWCs(
+    const usedKeyExpectedWCs = this.getUsedKeyExpectedWCs(
       lidoKeys,
       moduleAddressToWC,
     );
     const earliestDeposits = this.getEarliestDeposits(
       depositedEvents,
-      usedKeyAcceptableWCs,
+      usedKeyExpectedWCs,
     );
     const lidoWCs = new Set(Object.values(moduleAddressToWC));
 
     const frontRunnedKeys: string[] = [];
     for (const [pubkey, event] of earliestDeposits) {
-      const acceptableWCs = usedKeyAcceptableWCs.get(pubkey);
-      // A legacy WC (e.g. the pre-Merge 0x00 BLS WC) is a valid lido WC even
-      // though the module's current WC has since rotated, so skip it here.
-      if (acceptableWCs?.has(event.wc)) continue;
-      if (!lidoWCs.has(event.wc)) {
+      const expectedWC = usedKeyExpectedWCs.get(pubkey);
+      if (!expectedWC) continue;
+
+      const hasAcceptableWC = this.hasAcceptableWC(event, expectedWC);
+      const hasUnknownWC = !hasAcceptableWC && !lidoWCs.has(event.wc);
+
+      if (hasUnknownWC) {
         frontRunnedKeys.push(pubkey);
       }
     }
@@ -157,39 +176,41 @@ export class StakingModuleGuardService {
     lidoKeys: DeepReadonly<RegistryKey[]>,
     moduleAddressToWC: DeepReadonly<Record<string, string>>,
   ): boolean {
-    const usedKeyAcceptableWCs = this.getUsedKeyAcceptableWCs(
+    const usedKeyExpectedWCs = this.getUsedKeyExpectedWCs(
       lidoKeys,
       moduleAddressToWC,
     );
     const earliestDeposits = this.getEarliestDeposits(
       depositedEvents,
-      usedKeyAcceptableWCs,
+      usedKeyExpectedWCs,
     );
     const lidoWCs = new Set(Object.values(moduleAddressToWC));
 
-    const wrongWCTypeKeys: string[] = [];
+    const otherLidoWCsKeys: string[] = [];
     for (const [pubkey, event] of earliestDeposits) {
-      const acceptableWCs = usedKeyAcceptableWCs.get(pubkey);
-      // Acceptable WCs (current + legacy) are fine; only a lido WC that is
-      // neither is a wrong-type deposit.
-      if (acceptableWCs?.has(event.wc)) continue;
-      if (lidoWCs.has(event.wc)) {
-        wrongWCTypeKeys.push(pubkey);
+      const expectedWC = usedKeyExpectedWCs.get(pubkey);
+      if (!expectedWC) continue;
+
+      const hasAcceptableWC = this.hasAcceptableWC(event, expectedWC);
+      const hasOtherLidoWC = !hasAcceptableWC && lidoWCs.has(event.wc);
+
+      if (hasOtherLidoWC) {
+        otherLidoWCsKeys.push(pubkey);
       }
     }
 
     this.guardianMetricsService.collectWrongWCTypeMetrics(
-      wrongWCTypeKeys.length,
+      otherLidoWCsKeys.length,
     );
 
-    if (wrongWCTypeKeys.length > 0) {
+    if (otherLidoWCsKeys.length > 0) {
       this.logger.warn(
-        'Found deposited keys with wrong withdrawal credentials type',
-        { wrongWCTypeKeys },
+        'Found deposited keys with other Lido withdrawal credentials',
+        { otherLidoWCsKeys },
       );
     }
 
-    return wrongWCTypeKeys.length > 0;
+    return otherLidoWCsKeys.length > 0;
   }
 
   /**

--- a/src/guardian/staking-module-guard/staking-module-guard.service.ts
+++ b/src/guardian/staking-module-guard/staking-module-guard.service.ts
@@ -17,6 +17,8 @@ import { performance } from 'perf_hooks';
 import { RegistryKey } from 'keys-api/interfaces/RegistryKey';
 import { KeysApiService } from 'keys-api/keys-api.service';
 import { DeepReadonly } from 'common/ts-utils';
+import { Configuration } from 'common/config';
+import { getLegacyModuleWCs } from '../withdrawal-credentials';
 
 @Injectable()
 export class StakingModuleGuardService {
@@ -29,6 +31,7 @@ export class StakingModuleGuardService {
     private guardianMetricsService: GuardianMetricsService,
     private guardianMessageService: GuardianMessageService,
     private keysValidationService: KeysValidationService,
+    private config: Configuration,
   ) {}
 
   private lastContractsStateByModuleId: Record<number, ContractsState | null> =
@@ -60,21 +63,29 @@ export class StakingModuleGuardService {
   }
 
   /**
-   * Build a map of used lido keys to their expected withdrawal credentials
+   * Build a map of used lido keys to the withdrawal credentials that are
+   * acceptable for them: the module's current WC plus any legacy WCs the module
+   * legitimately used in the past (e.g. the pre-Merge 0x00 BLS WC). The earliest
+   * deposit of a used key may still be bound to a legacy WC, so it must be
+   * treated as a valid lido WC and not reported as a front-run.
    */
-  private getUsedKeyExpectedWC(
+  private getUsedKeyAcceptableWCs(
     lidoKeys: DeepReadonly<RegistryKey[]>,
     moduleAddressToWC: DeepReadonly<Record<string, string>>,
-  ): Map<string, string> {
-    const usedKeyExpectedWC = new Map<string, string>();
+  ): Map<string, Set<string>> {
+    const usedKeyAcceptableWCs = new Map<string, Set<string>>();
     for (const key of lidoKeys) {
       if (key.used) {
         const expectedWC = moduleAddressToWC[key.moduleAddress];
         if (!expectedWC) throw new Error('Unexpected module address');
-        usedKeyExpectedWC.set(key.key, expectedWC);
+        const legacyWCs = getLegacyModuleWCs(
+          this.config.CHAIN_ID,
+          key.moduleAddress,
+        );
+        usedKeyAcceptableWCs.set(key.key, new Set([expectedWC, ...legacyWCs]));
       }
     }
-    return usedKeyExpectedWC;
+    return usedKeyAcceptableWCs;
   }
 
   /**
@@ -82,12 +93,12 @@ export class StakingModuleGuardService {
    */
   private getEarliestDeposits(
     depositedEvents: VerifiedDepositEventGroup,
-    usedKeyExpectedWC: Map<string, string>,
+    usedKeyAcceptableWCs: Map<string, Set<string>>,
   ): Map<string, VerifiedDepositEvent> {
     const earliestDeposits = new Map<string, VerifiedDepositEvent>();
     for (const event of depositedEvents.events) {
       if (!event.valid) continue;
-      if (!usedKeyExpectedWC.has(event.pubkey)) continue;
+      if (!usedKeyAcceptableWCs.has(event.pubkey)) continue;
 
       const existing = earliestDeposits.get(event.pubkey);
       if (!existing || this.isFirstEventEarlier(event, existing)) {
@@ -105,18 +116,22 @@ export class StakingModuleGuardService {
     lidoKeys: DeepReadonly<RegistryKey[]>,
     moduleAddressToWC: DeepReadonly<Record<string, string>>,
   ): boolean {
-    const usedKeyExpectedWC = this.getUsedKeyExpectedWC(
+    const usedKeyAcceptableWCs = this.getUsedKeyAcceptableWCs(
       lidoKeys,
       moduleAddressToWC,
     );
     const earliestDeposits = this.getEarliestDeposits(
       depositedEvents,
-      usedKeyExpectedWC,
+      usedKeyAcceptableWCs,
     );
     const lidoWCs = new Set(Object.values(moduleAddressToWC));
 
     const frontRunnedKeys: string[] = [];
     for (const [pubkey, event] of earliestDeposits) {
+      const acceptableWCs = usedKeyAcceptableWCs.get(pubkey);
+      // A legacy WC (e.g. the pre-Merge 0x00 BLS WC) is a valid lido WC even
+      // though the module's current WC has since rotated, so skip it here.
+      if (acceptableWCs?.has(event.wc)) continue;
       if (!lidoWCs.has(event.wc)) {
         frontRunnedKeys.push(pubkey);
       }
@@ -124,7 +139,6 @@ export class StakingModuleGuardService {
 
     this.guardianMetricsService.collectHistoricalFrontRunMetrics(
       frontRunnedKeys.length,
-      0,
     );
 
     if (frontRunnedKeys.length > 0) {
@@ -143,26 +157,28 @@ export class StakingModuleGuardService {
     lidoKeys: DeepReadonly<RegistryKey[]>,
     moduleAddressToWC: DeepReadonly<Record<string, string>>,
   ): boolean {
-    const usedKeyExpectedWC = this.getUsedKeyExpectedWC(
+    const usedKeyAcceptableWCs = this.getUsedKeyAcceptableWCs(
       lidoKeys,
       moduleAddressToWC,
     );
     const earliestDeposits = this.getEarliestDeposits(
       depositedEvents,
-      usedKeyExpectedWC,
+      usedKeyAcceptableWCs,
     );
     const lidoWCs = new Set(Object.values(moduleAddressToWC));
 
     const wrongWCTypeKeys: string[] = [];
     for (const [pubkey, event] of earliestDeposits) {
-      const expectedWC = usedKeyExpectedWC.get(pubkey);
-      if (lidoWCs.has(event.wc) && event.wc !== expectedWC) {
+      const acceptableWCs = usedKeyAcceptableWCs.get(pubkey);
+      // Acceptable WCs (current + legacy) are fine; only a lido WC that is
+      // neither is a wrong-type deposit.
+      if (acceptableWCs?.has(event.wc)) continue;
+      if (lidoWCs.has(event.wc)) {
         wrongWCTypeKeys.push(pubkey);
       }
     }
 
-    this.guardianMetricsService.collectHistoricalFrontRunMetrics(
-      0,
+    this.guardianMetricsService.collectWrongWCTypeMetrics(
       wrongWCTypeKeys.length,
     );
 

--- a/src/guardian/staking-module-guard/staking-module-guard.spec.ts
+++ b/src/guardian/staking-module-guard/staking-module-guard.spec.ts
@@ -3,7 +3,7 @@ import { LoggerModule } from 'common/logger';
 import { MockProviderModule } from 'provider';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { LoggerService } from '@nestjs/common';
-import { ConfigModule } from 'common/config';
+import { ConfigModule, Configuration } from 'common/config';
 import { PrometheusModule } from 'common/prometheus';
 import { SecurityModule, SecurityService } from 'contracts/security';
 import { RepositoryModule } from 'contracts/repository';
@@ -47,6 +47,7 @@ describe('StakingModuleGuardService', () => {
   let stakingModuleGuardService: StakingModuleGuardService;
   let guardianMessageService: GuardianMessageService;
   let keysApiService: KeysApiService;
+  let configuration: Configuration;
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
@@ -82,6 +83,7 @@ describe('StakingModuleGuardService', () => {
     stakingModuleGuardService = moduleRef.get(StakingModuleGuardService);
     guardianMessageService = moduleRef.get(GuardianMessageService);
     keysApiService = moduleRef.get(KeysApiService);
+    configuration = moduleRef.get(Configuration);
 
     jest.spyOn(loggerService, 'log').mockImplementation(() => undefined);
     jest.spyOn(loggerService, 'warn').mockImplementation(() => undefined);
@@ -540,6 +542,38 @@ describe('StakingModuleGuardService', () => {
         ),
       ).toThrow('Unexpected module address');
     });
+
+    describe('legacy withdrawal credentials (0x00 BLS -> 0x01 rotation)', () => {
+      // mainnet Curated module, checksummed to also cover case-insensitive match
+      const LEGACY_MODULE_ADDR = '0x55032650b14df07b85bF18A3a3eC8E0Af2e028d5';
+      const LEGACY_WC =
+        '0x009690e5d4472c7c0dbdf490425d89862535d2a52fb686333f3a0a9ff5d2125e';
+
+      it('should return false when earliest deposit uses the module legacy WC on mainnet', () => {
+        configuration.CHAIN_ID = 1;
+        const result = stakingModuleGuardService.checkHistoricalFrontRun(
+          {
+            events: [
+              makeEvent('0xkeyLegacy', LEGACY_WC, 50, 0),
+              makeEvent('0xkeyLegacy', WC_01, 200, 0),
+            ],
+          } as any,
+          [makeLidoKey('0xkeyLegacy', LEGACY_MODULE_ADDR, true)],
+          { [LEGACY_MODULE_ADDR]: WC_01 },
+        );
+        expect(result).toBe(false);
+      });
+
+      it('should return true when the same legacy WC is used on a chain without a legacy list', () => {
+        configuration.CHAIN_ID = 560048; // hoodi: no legacy WCs configured
+        const result = stakingModuleGuardService.checkHistoricalFrontRun(
+          { events: [makeEvent('0xkeyLegacy', LEGACY_WC, 50, 0)] } as any,
+          [makeLidoKey('0xkeyLegacy', LEGACY_MODULE_ADDR, true)],
+          { [LEGACY_MODULE_ADDR]: WC_01 },
+        );
+        expect(result).toBe(true);
+      });
+    });
   });
 
   describe('checkWrongWCType', () => {
@@ -667,6 +701,24 @@ describe('StakingModuleGuardService', () => {
           { [MODULE_ADDR_01]: WC_01 },
         ),
       ).toThrow('Unexpected module address');
+    });
+
+    it('should return false when earliest deposit uses the module legacy WC (not wrong type)', () => {
+      const LEGACY_MODULE_ADDR = '0x55032650b14df07b85bF18A3a3eC8E0Af2e028d5';
+      const LEGACY_WC =
+        '0x009690e5d4472c7c0dbdf490425d89862535d2a52fb686333f3a0a9ff5d2125e';
+      configuration.CHAIN_ID = 1;
+      const result = stakingModuleGuardService.checkWrongWCType(
+        {
+          events: [
+            makeEvent('0xkeyLegacy', LEGACY_WC, 50, 0),
+            makeEvent('0xkeyLegacy', WC_01, 200, 0),
+          ],
+        } as any,
+        [makeLidoKey('0xkeyLegacy', LEGACY_MODULE_ADDR, true)],
+        { [LEGACY_MODULE_ADDR]: WC_01 },
+      );
+      expect(result).toBe(false);
     });
   });
 

--- a/src/guardian/staking-module-guard/staking-module-guard.spec.ts
+++ b/src/guardian/staking-module-guard/staking-module-guard.spec.ts
@@ -11,6 +11,7 @@ import { StakingModuleGuardModule } from './staking-module-guard.module';
 import { GuardianMetricsModule } from '../guardian-metrics';
 import { GuardianMessageService } from '../guardian-message';
 import { StakingModuleGuardService } from './staking-module-guard.service';
+import { LEGACY_WITHDRAWAL_CREDENTIALS } from '../withdrawal-credentials';
 
 import { KeysValidationModule } from 'guardian/keys-validation/keys-validation.module';
 import { vettedKeys } from './keys.fixtures';
@@ -548,20 +549,53 @@ describe('StakingModuleGuardService', () => {
       const LEGACY_MODULE_ADDR = '0x55032650b14df07b85bF18A3a3eC8E0Af2e028d5';
       const LEGACY_WC =
         '0x009690e5d4472c7c0dbdf490425d89862535d2a52fb686333f3a0a9ff5d2125e';
+      const LEGACY_VALID_UNTIL_BLOCK =
+        LEGACY_WITHDRAWAL_CREDENTIALS[1][
+          LEGACY_MODULE_ADDR.toLowerCase()
+        ][0].validUntilBlock;
 
       it('should return false when earliest deposit uses the module legacy WC on mainnet', () => {
         configuration.CHAIN_ID = 1;
         const result = stakingModuleGuardService.checkHistoricalFrontRun(
           {
             events: [
-              makeEvent('0xkeyLegacy', LEGACY_WC, 50, 0),
-              makeEvent('0xkeyLegacy', WC_01, 200, 0),
+              makeEvent(
+                '0xkeyLegacy',
+                LEGACY_WC,
+                LEGACY_VALID_UNTIL_BLOCK,
+                0,
+              ),
+              makeEvent(
+                '0xkeyLegacy',
+                WC_01,
+                LEGACY_VALID_UNTIL_BLOCK + 1,
+                0,
+              ),
             ],
           } as any,
           [makeLidoKey('0xkeyLegacy', LEGACY_MODULE_ADDR, true)],
           { [LEGACY_MODULE_ADDR]: WC_01 },
         );
         expect(result).toBe(false);
+      });
+
+      it('should return true when earliest legacy WC deposit is after its cutoff block', () => {
+        configuration.CHAIN_ID = 1;
+        const result = stakingModuleGuardService.checkHistoricalFrontRun(
+          {
+            events: [
+              makeEvent(
+                '0xkeyLegacyAfterCutoff',
+                LEGACY_WC,
+                LEGACY_VALID_UNTIL_BLOCK + 1,
+                0,
+              ),
+            ],
+          } as any,
+          [makeLidoKey('0xkeyLegacyAfterCutoff', LEGACY_MODULE_ADDR, true)],
+          { [LEGACY_MODULE_ADDR]: WC_01 },
+        );
+        expect(result).toBe(true);
       });
 
       it('should return true when the same legacy WC is used on a chain without a legacy list', () => {

--- a/src/guardian/withdrawal-credentials.ts
+++ b/src/guardian/withdrawal-credentials.ts
@@ -26,25 +26,34 @@ export function buildModuleWc(
  * Legacy (historical) withdrawal credentials that were legitimately used by a
  * Lido module before its withdrawal credentials were rotated on-chain.
  *
- * The very first Lido deposits used 0x00 BLS withdrawal credentials before The
- * Merge; the WC was later rotated to the 0x01 withdrawal vault. Those early
- * `used` keys still have their earliest deposit bound to the old 0x00 WC, which
- * the contracts no longer return. Without this list the historical front-run
- * check would mis-detect those legitimate legacy deposits as theft and pause
- * the module.
+ * The very first Lido deposits used 0x00 BLS withdrawal credentials; the WC was
+ * later rotated to the 0x01 withdrawal vault. Those early `used` keys still have
+ * their earliest deposit bound to the old 0x00 WC, which the contracts no
+ * longer return. Without this list the historical front-run check would
+ * mis-detect those legitimate legacy deposits as theft and pause the module.
  *
- * Keyed by chain id -> lowercased staking module address -> legacy WCs. Only
- * applies to `used` keys (historical front-run check); vetted-unused keys that
- * reappear with a legacy WC are still treated as a front-run attempt.
+ * Keyed by chain id -> lowercased staking module address -> legacy WCs with
+ * cutoff blocks. Only applies to `used` keys (historical front-run check);
+ * vetted-unused keys that reappear with a legacy WC are still treated as a
+ * front-run attempt.
  */
+export type LegacyWithdrawalCredential = {
+  wc: string;
+  validUntilBlock: number;
+};
+
 export const LEGACY_WITHDRAWAL_CREDENTIALS: Record<
   number,
-  Record<string, string[]>
+  Record<string, LegacyWithdrawalCredential[]>
 > = {
   // mainnet, Curated module (module id 1)
   1: {
     '0x55032650b14df07b85bf18a3a3ec8e0af2e028d5': [
-      '0x009690e5d4472c7c0dbdf490425d89862535d2a52fb686333f3a0a9ff5d2125e',
+      {
+        wc: '0x009690e5d4472c7c0dbdf490425d89862535d2a52fb686333f3a0a9ff5d2125e',
+        // SRv3 snapshot block: no active Lido validators still had 0x00 WC.
+        validUntilBlock: 25444424,
+      },
     ],
   },
 };
@@ -57,7 +66,7 @@ export const LEGACY_WITHDRAWAL_CREDENTIALS: Record<
 export function getLegacyModuleWCs(
   chainId: number,
   moduleAddress: string,
-): string[] {
+): LegacyWithdrawalCredential[] {
   return (
     LEGACY_WITHDRAWAL_CREDENTIALS[chainId]?.[moduleAddress.toLowerCase()] ?? []
   );

--- a/src/guardian/withdrawal-credentials.ts
+++ b/src/guardian/withdrawal-credentials.ts
@@ -21,3 +21,44 @@ export function buildModuleWc(
   // drop the base "0x" + type byte (4 chars) and prepend the module's type byte
   return typePrefix + baseWC.slice(4);
 }
+
+/**
+ * Legacy (historical) withdrawal credentials that were legitimately used by a
+ * Lido module before its withdrawal credentials were rotated on-chain.
+ *
+ * The very first Lido deposits used 0x00 BLS withdrawal credentials before The
+ * Merge; the WC was later rotated to the 0x01 withdrawal vault. Those early
+ * `used` keys still have their earliest deposit bound to the old 0x00 WC, which
+ * the contracts no longer return. Without this list the historical front-run
+ * check would mis-detect those legitimate legacy deposits as theft and pause
+ * the module.
+ *
+ * Keyed by chain id -> lowercased staking module address -> legacy WCs. Only
+ * applies to `used` keys (historical front-run check); vetted-unused keys that
+ * reappear with a legacy WC are still treated as a front-run attempt.
+ */
+export const LEGACY_WITHDRAWAL_CREDENTIALS: Record<
+  number,
+  Record<string, string[]>
+> = {
+  // mainnet, Curated module (module id 1)
+  1: {
+    '0x55032650b14df07b85bf18a3a3ec8e0af2e028d5': [
+      '0x009690e5d4472c7c0dbdf490425d89862535d2a52fb686333f3a0a9ff5d2125e',
+    ],
+  },
+};
+
+/**
+ * Legacy withdrawal credentials that the given module legitimately used in the
+ * past on the given chain (case-insensitive on the module address). Empty when
+ * the module never rotated its WC.
+ */
+export function getLegacyModuleWCs(
+  chainId: number,
+  moduleAddress: string,
+): string[] {
+  return (
+    LEGACY_WITHDRAWAL_CREDENTIALS[chainId]?.[moduleAddress.toLowerCase()] ?? []
+  );
+}

--- a/test/helpers/dsm.ts
+++ b/test/helpers/dsm.ts
@@ -116,13 +116,13 @@ export async function fillLidoBuffer(depositCount = 1) {
     throw new Error(`DAO address not found for chain ID: ${chainId}`);
   }
 
+  // The Aragon Agent manages DAO ACL permissions on fork/devnet.
   await accountImpersonate(agent);
-  await accountImpersonate(daoAddress);
   await setBalance(agent, 100);
 
   const agentSigner = testSetupProvider.getSigner(agent);
-  const lido = LidoAbi__factory.connect(lidoAddress, agentSigner);
-  const lidoAgentSigner = LidoAbi__factory.connect(lidoAddress, agentSigner);
+  const lido = LidoAbi__factory.connect(lidoAddress, testSetupProvider);
+  const lidoWithAgent = lido.connect(agentSigner);
 
   const withdrawalQueue = new Contract(
     withdrawalQueueAddress,
@@ -157,7 +157,7 @@ export async function fillLidoBuffer(depositCount = 1) {
   );
   await grantTx.wait();
 
-  await lidoAgentSigner.setStakingLimit(
+  await lidoWithAgent.setStakingLimit(
     ethers.utils.parseEther(amountForDepositsInEth),
     ethers.utils.parseEther(amountForDepositsInEth),
   );


### PR DESCRIPTION
**Fix historical front-run false positive for legacy withdrawal credentials**

Some mainnet Curated module keys were deposited with the 0x00 BLS withdrawal credentials before the WC was rotated to 0x01. The historical front-run check only compared against the current on-chain WC, so those legitimate legacy deposits were flagged as theft and could pause the module. We now keep a per-network/per-module list of legacy WCs (mainnet module 1 → 0x0096…125e) and treat them as valid for used keys. Vetted-unused keys are unchanged (still unvetted on mismatch).

Also split the front-run / wrong-WC-type metrics into two methods so they no longer overwrite each other.